### PR TITLE
Use HTTPS to request descriptions of Reactome IDs

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
@@ -25,7 +25,7 @@ public class ReactomeClient {
 
     @Nullable
     public String fetchPathwayNameFailSafe(String reactomeId) {
-        String reactomeURL = "http://reactome.org/ContentService/data/query/{0}/displayName";
+        String reactomeURL = "https://reactome.org/ContentService/data/query/{0}/displayName";
         String url = MessageFormat.format(reactomeURL, reactomeId);
 
         try {


### PR DESCRIPTION
Passes all tests: http://bar:8085/browse/ATLAS-BASECIDEVTASKS0-1

`ReactomeClientEIT.java` checks that the descriptions for the pathway IDs are returned.