### PR TITLE
Cache gene distributions per experiment when start up the app

### DIFF
--- a/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
+++ b/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
 # @author: barrera
 # @date:   27 Sept 2017
 
@@ -20,8 +22,15 @@ len=$(echo "$EXPERIMENTS_RESULTS" | jq .[] | jq length)
 
 curl ${ATLAS_ROOT_URL}/json/experiments | jq -r '.aaData | map(select(.experimentType=="RNASEQ_MRNA_BASELINE")) | map(.experimentAccession)[]' | while read -r experimentAccession; do {
 	GENE_DISTRIBUTION=${ATLAS_ROOT_URL}/json/experiments/${experimentAccession}/genedistribution
-	curl -s -o /dev/null -w "HTTP status code: %{http_code} Size: %{size_download} Time: %{time_total}\\n" ${GENE_DISTRIBUTION}
+
+    STATUS=$(curl -s -S -o /dev/null -w '%{http_code}' ${GENE_DISTRIBUTION})
+    if [ $STATUS -eq 200 ]; then
+        echo "Finished"
+        break
+    else
+        echo "Got $STATUS (error while processing" ${experimentAccession} ")"
+    fi
+  sleep 10
+
 }
 done
-
-echo "Finished"

--- a/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
+++ b/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
@@ -17,20 +17,17 @@ PORT=8080
 ATLAS_ROOT_URL="http://${HOSTNAME}:${PORT}/gxa"
 EXPERIMENTS=${ATLAS_ROOT_URL}/json/experiments
 
-EXPERIMENTS_RESULTS=$(curl ${EXPERIMENTS})
+EXPERIMENTS_RESULTS=$(curl -s -S ${EXPERIMENTS})
 len=$(echo "$EXPERIMENTS_RESULTS" | jq .[] | jq length)
 
-curl ${ATLAS_ROOT_URL}/json/experiments | jq -r '.aaData | map(select(.experimentType=="RNASEQ_MRNA_BASELINE")) | map(.experimentAccession)[]' | while read -r experimentAccession; do {
+curl -s -S ${ATLAS_ROOT_URL}/json/experiments | jq -r '.aaData | map(select(.experimentType=="RNASEQ_MRNA_BASELINE")) | map(.experimentAccession)[]' | while read -r experimentAccession; do {
 	GENE_DISTRIBUTION=${ATLAS_ROOT_URL}/json/experiments/${experimentAccession}/genedistribution
-
     STATUS=$(curl -s -S -o /dev/null -w '%{http_code}' ${GENE_DISTRIBUTION})
-    if [ $STATUS -eq 200 ]; then
-        echo "Finished"
-        break
-    else
-        echo "Got $STATUS (error while processing" ${experimentAccession} ")"
+    if [ "$STATUS" != 200 ]; then
+        echo "Got error HTTP $STATUS for: $GENE_DISTRIBUTION " >&2
+        sleep 10
     fi
-  sleep 10
-
 }
 done
+
+echo "Finished!"

--- a/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
+++ b/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# @author: barrera
+# @date:   27 Sept 2017
+
+if [ $# -lt 1 ]; then
+        echo "Accesses the json URL gene distribution per experiment accession and after application startup"
+        echo "will load all gene distribution per experiments into cache."
+        echo
+        echo "Usage: $0 HOSTNAME"
+        exit;
+fi
+
+HOSTNAME=$1
+PORT=8080
+ATLAS_ROOT_URL="http://${HOSTNAME}:${PORT}/gxa"
+EXPERIMENTS=${ATLAS_ROOT_URL}/json/experiments
+
+EXPERIMENTS_RESULTS=$(curl ${EXPERIMENTS})
+len=$(echo "$EXPERIMENTS_RESULTS" | jq .[] | jq length)
+
+for((i=0; i<$len; i++)) {
+    experimentAccession=$(echo "$EXPERIMENTS_RESULTS" | jq -r .aaData["$i"].experimentAccession)
+    experimentType=$(echo "$EXPERIMENTS_RESULTS" | jq -r .aaData["$i"].experimentType)
+
+    if [ "${experimentType}" == "RNASEQ_MRNA_BASELINE" ]
+    then
+        GENE_DISTRIBUTION=${ATLAS_ROOT_URL}/json/experiments/${experimentAccession}/genedistribution
+        curl -s -o /dev/null -w "HTTP status code: %{http_code} Size: %{size_download} Time: %{time_total}\\n" ${GENE_DISTRIBUTION}
+    fi
+}
+
+echo "Finished"

--- a/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
+++ b/atlas-misc/scripts/warm_experiments_genedistribution_cache.sh
@@ -18,15 +18,10 @@ EXPERIMENTS=${ATLAS_ROOT_URL}/json/experiments
 EXPERIMENTS_RESULTS=$(curl ${EXPERIMENTS})
 len=$(echo "$EXPERIMENTS_RESULTS" | jq .[] | jq length)
 
-for((i=0; i<$len; i++)) {
-    experimentAccession=$(echo "$EXPERIMENTS_RESULTS" | jq -r .aaData["$i"].experimentAccession)
-    experimentType=$(echo "$EXPERIMENTS_RESULTS" | jq -r .aaData["$i"].experimentType)
-
-    if [ "${experimentType}" == "RNASEQ_MRNA_BASELINE" ]
-    then
-        GENE_DISTRIBUTION=${ATLAS_ROOT_URL}/json/experiments/${experimentAccession}/genedistribution
-        curl -s -o /dev/null -w "HTTP status code: %{http_code} Size: %{size_download} Time: %{time_total}\\n" ${GENE_DISTRIBUTION}
-    fi
+curl ${ATLAS_ROOT_URL}/json/experiments | jq -r '.aaData | map(select(.experimentType=="RNASEQ_MRNA_BASELINE")) | map(.experimentAccession)[]' | while read -r experimentAccession; do {
+	GENE_DISTRIBUTION=${ATLAS_ROOT_URL}/json/experiments/${experimentAccession}/genedistribution
+	curl -s -o /dev/null -w "HTTP status code: %{http_code} Size: %{size_download} Time: %{time_total}\\n" ${GENE_DISTRIBUTION}
 }
+done
 
 echo "Finished"


### PR DESCRIPTION
Code has a script that extracts from all baseline experiments the experimentAccession and the experimentType and uses them to access the json URL to warm the gene distribution for each of them.