### PR TITLE
Fix bug

### DIFF
--- a/gxa/src/main/webapp/resources/js/foundationExperimentsPageModule.js
+++ b/gxa/src/main/webapp/resources/js/foundationExperimentsPageModule.js
@@ -150,7 +150,7 @@ var foundationExperimentsPageModule = (function ($) {
                     } },
                 { "title":"Assays", "data":"numberOfAssays", "className":"center", "type":"title-numeric", "width":"5%",
                     "render": function (data, type, full) {
-                        return replaceZeroAndLinkExpDesign(data, type, full);
+                        return replaceZeroAndLinkExpDesign(data, full);
                     } },
                 { "title":"Comparisons", "data":"numberOfContrasts", "className":"center", "type":"title-numeric", "width":"5%",
                     "render": function (data, type, full) {


### PR DESCRIPTION
replaceZeroAndLinkExpDesign takes two arguments, not three