### PR TITLE
Task 152003874

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/bioentity/geneset/GeneSetPropertyService.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/bioentity/geneset/GeneSetPropertyService.java
@@ -52,7 +52,7 @@ public class GeneSetPropertyService {
 
     private Map<BioentityPropertyName, Set<String>> propertyValuesByType(BioentityPropertyName which,
                                                                          String identifier, String value) {
-        return ImmutableMap.of(which, (Set<String>)ImmutableSet.of(identifier), DESCRIPTION, ImmutableSet.of(value));
+        return ImmutableMap.of(which, ImmutableSet.of(identifier), DESCRIPTION, ImmutableSet.of(value));
     }
 
 }

--- a/base/src/main/java/uk/ac/ebi/atlas/bioentity/geneset/GeneSetPropertyService.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/bioentity/geneset/GeneSetPropertyService.java
@@ -38,13 +38,13 @@ public class GeneSetPropertyService {
     public Map<BioentityPropertyName, Set<String>> propertyValuesByType(String identifier) {
         identifier = identifier.toUpperCase();
         if (GeneSetUtil.matchesReactomeID(identifier)) {
-            return propertyValuesByType(PATHWAYID, identifier, reactomeClient.fetchPathwayNameFailSafe(identifier));
+            return propertyValuesByType(PATHWAYID, identifier, reactomeClient.fetchPathwayNameFailSafe(identifier).orElse(""));
         } else if (GeneSetUtil.matchesGeneOntologyAccession(identifier)) {
-            return propertyValuesByType(GO, identifier, goPoTermTrader.getTermName(identifier));
+            return propertyValuesByType(GO, identifier, goPoTermTrader.getTermName(identifier).orElse(""));
         } else if (GeneSetUtil.matchesPlantOntologyAccession(identifier)) {
-            return propertyValuesByType(PO, identifier, goPoTermTrader.getTermName(identifier));
+            return propertyValuesByType(PO, identifier, goPoTermTrader.getTermName(identifier).orElse(""));
         }else if (GeneSetUtil.matchesInterProAccession(identifier)) {
-            return propertyValuesByType(INTERPRO, identifier, interProTermTrader.getTermName(identifier));
+            return propertyValuesByType(INTERPRO, identifier, interProTermTrader.getTermName(identifier).orElse(""));
         } else {
             return ImmutableMap.of();
         }

--- a/base/src/main/java/uk/ac/ebi/atlas/bioentity/go/GoPoTrader.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/bioentity/go/GoPoTrader.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
+import java.util.Optional;
 
 @Named
 public class GoPoTrader {
@@ -28,18 +29,16 @@ public class GoPoTrader {
         }
     }
 
-    @Nullable
-    public OntologyTerm getTerm(String accession) {
-        return accessionToTerm.get(accession);
+    public Optional<OntologyTerm> getTerm(String accession) {
+        return Optional.ofNullable(accessionToTerm.get(accession));
     }
 
-    @Nullable
-    public String getTermName(String accession) {
+    public Optional<String> getTermName(String accession) {
         try {
-            return accessionToTerm.get(accession).name();
+            return Optional.of(accessionToTerm.get(accession).name());
         } catch (NullPointerException e) {
             LOGGER.warn("Unknown name for GO/PO term with ID {}", accession);
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/base/src/main/java/uk/ac/ebi/atlas/bioentity/interpro/InterProTrader.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/bioentity/interpro/InterProTrader.java
@@ -7,10 +7,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
+import java.util.Optional;
 
 @Named
 public class InterProTrader {
@@ -27,13 +27,12 @@ public class InterProTrader {
         }
     }
 
-    @Nullable
-    public String getTermName(String accession) {
+    public Optional<String> getTermName(String accession) {
         try {
-            return interProAccessionToTerm.get(accession);
+            return Optional.of(interProAccessionToTerm.get(accession));
         } catch (NullPointerException e) {
             LOGGER.warn("Unknown name for InterPro term with ID {}", accession);
-            return null;
+            return Optional.empty();
         }
 
     }

--- a/base/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyLinkTextService.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyLinkTextService.java
@@ -8,12 +8,8 @@ import uk.ac.ebi.atlas.species.Species;
 import uk.ac.ebi.atlas.species.SpeciesInferrer;
 import uk.ac.ebi.atlas.utils.ReactomeClient;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.text.MessageFormat;
 import java.util.Optional;
 import java.util.Set;
 
@@ -39,12 +35,11 @@ public class BioEntityPropertyLinkTextService {
 
     }
 
-    @Nullable
-    public String getLinkTextOrNull(BioentityPropertyName propertyName, String propertyValue) {
+    public Optional<String> getLinkText(BioentityPropertyName propertyName, String propertyValue) {
 
         switch (propertyName) {
             case ORTHOLOG:
-                return fetchSymbolAndSpeciesForOrtholog(propertyValue);
+                return Optional.of(fetchSymbolAndSpeciesForOrtholog(propertyValue));
             case PATHWAYID:
                 return reactomeClient.fetchPathwayNameFailSafe(propertyValue);
             case GO:
@@ -54,7 +49,7 @@ public class BioEntityPropertyLinkTextService {
             case PO:
                 return goPoTermTrader.getTermName(propertyValue);
             default:
-                return propertyValue;
+                return Optional.of(propertyValue);
         }
 
     }

--- a/base/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyService.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyService.java
@@ -18,7 +18,12 @@ import javax.inject.Named;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Named
@@ -122,8 +127,7 @@ public class BioEntityPropertyService {
     private int assessRelevance(BioentityPropertyName bioentityPropertyName, String propertyValue) {
 
         if (ImmutableList.of(BioentityPropertyName.GO, BioentityPropertyName.PO).contains(bioentityPropertyName)) {
-            OntologyTerm o = goPoTermTrader.getTerm(propertyValue);
-            return o != null ? o.depth() : 0;
+            return goPoTermTrader.getTerm(propertyValue).map(OntologyTerm::depth).orElse(0);
         } else {
             return 0;
         }
@@ -158,7 +162,7 @@ public class BioEntityPropertyService {
     PropertyLink createLink(String identifier, BioentityPropertyName propertyName,
                                    String propertyValue, Species species, int relevance) {
         return new PropertyLink(
-                Optional.ofNullable(linkBuilder.getLinkTextOrNull(propertyName, propertyValue)).orElse(propertyValue),
+                linkBuilder.getLinkText(propertyName, propertyValue).orElse(propertyValue),
                 Optional.ofNullable(BioEntityCardProperties.linkTemplates.get(propertyName)).map(
                         linkTemplate -> MessageFormat.format(
                                 linkTemplate,

--- a/base/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
@@ -6,10 +6,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 @Named
 public class ReactomeClient {
@@ -23,16 +23,15 @@ public class ReactomeClient {
         this.restTemplate = restTemplate;
     }
 
-    @Nullable
-    public String fetchPathwayNameFailSafe(String reactomeId) {
+    public Optional<String> fetchPathwayNameFailSafe(String reactomeId) {
         String reactomeURL = "https://reactome.org/ContentService/data/query/{0}/displayName";
         String url = MessageFormat.format(reactomeURL, reactomeId);
 
         try {
-            return StringUtils.trim(restTemplate.getForObject(url, String.class));
+            return Optional.of(StringUtils.trim(restTemplate.getForObject(url, String.class)));
         } catch (RestClientException e) {
             LOGGER.warn("Reactome ID \"{}\" could not be found", reactomeId);
-            return "";
+            return Optional.empty();
         }
 
     }

--- a/base/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
@@ -32,7 +32,7 @@ public class ReactomeClient {
             return StringUtils.trim(restTemplate.getForObject(url, String.class));
         } catch (RestClientException e) {
             LOGGER.warn("Reactome ID \"{}\" could not be found", reactomeId);
-            return null;
+            return "";
         }
 
     }

--- a/base/src/test/java/uk/ac/ebi/atlas/bioentity/geneset/GeneSetPropertyServiceTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/bioentity/geneset/GeneSetPropertyServiceTest.java
@@ -12,6 +12,7 @@ import uk.ac.ebi.atlas.model.experiment.baseline.BioentityPropertyName;
 import uk.ac.ebi.atlas.utils.ReactomeClient;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.hasEntry;
@@ -40,10 +41,10 @@ public class GeneSetPropertyServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        when(reactomeClientMock.fetchPathwayNameFailSafe(startsWith("R-"))).thenReturn("some pathway name");
-        when(goPoTermTraderMock.getTermName(startsWith("GO:"))).thenReturn("some GO term name");
-        when(goPoTermTraderMock.getTermName(startsWith("PO:"))).thenReturn("some PO term name");
-        when(interProTermTraderMock.getTermName(startsWith("IPR"))).thenReturn("some InterPro term name");
+        when(reactomeClientMock.fetchPathwayNameFailSafe(startsWith("R-"))).thenReturn(Optional.of("some pathway name"));
+        when(goPoTermTraderMock.getTermName(startsWith("GO:"))).thenReturn(Optional.of("some GO term name"));
+        when(goPoTermTraderMock.getTermName(startsWith("PO:"))).thenReturn(Optional.of("some PO term name"));
+        when(interProTermTraderMock.getTermName(startsWith("IPR"))).thenReturn(Optional.of("some InterPro term name"));
         subject = new GeneSetPropertyService(goPoTermTraderMock, interProTermTraderMock, reactomeClientMock);
     }
 

--- a/base/src/test/java/uk/ac/ebi/atlas/bioentity/go/GoPoTraderIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/bioentity/go/GoPoTraderIT.java
@@ -8,6 +8,8 @@ import uk.ac.ebi.atlas.model.OntologyTerm;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -30,41 +32,41 @@ public class GoPoTraderIT {
 
     @Test
     public void hasGO_0000001() throws Exception {
-        assertThat(subject.getTerm(GO_0000001), is(GO_0000001_TERM));
+        assertThat(subject.getTerm(GO_0000001), is(Optional.of(GO_0000001_TERM)));
     }
 
     @Test
     public void hasGO_2001317() throws Exception {
-        assertThat(subject.getTerm(GO_2001317), is(GO_2001317_TERM));
+        assertThat(subject.getTerm(GO_2001317), is(Optional.of(GO_2001317_TERM)));
     }
 
     @Test
     public void hasPO_0000001() throws Exception {
-        assertThat(subject.getTerm(PO_0000001), is(PO_0000001_TERM));
+        assertThat(subject.getTerm(PO_0000001), is(Optional.of(PO_0000001_TERM)));
     }
 
     @Test
     public void hasPO_0030087() throws Exception {
-        assertThat(subject.getTerm(PO_0030087), is(PO_0030087_TERM));
+        assertThat(subject.getTerm(PO_0030087), is(Optional.of(PO_0030087_TERM)));
     }
 
     @Test
     public void goTermName() throws Exception {
-        assertThat(subject.getTermName(GO_0000001), is(GO_0000001_TERM.name()));
+        assertThat(subject.getTermName(GO_0000001), is(Optional.of(GO_0000001_TERM.name())));
     }
 
     @Test
     public void poTermName() throws Exception {
-        assertThat(subject.getTermName(PO_0030087), is(PO_0030087_TERM.name()));
+        assertThat(subject.getTermName(PO_0030087), is(Optional.of(PO_0030087_TERM.name())));
     }
 
     @Test
     public void noTerm() throws Exception {
-        assertThat(subject.getTerm("FO:OBAR"), is(nullValue()));
+        assertThat(subject.getTerm("FO:OBAR"), is(Optional.empty()));
     }
 
     @Test
     public void noTermName() throws Exception {
-        assertThat(subject.getTermName("FO:OBAR"), is(nullValue()));
+        assertThat(subject.getTermName("FO:OBAR"), is(Optional.empty()));
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/bioentity/interpro/InterProTraderIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/bioentity/interpro/InterProTraderIT.java
@@ -7,6 +7,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -25,16 +27,16 @@ public class InterProTraderIT {
 
     @Test
     public void hasFirstTerm() {
-        assertThat(subject.getTermName(IPR000001), is(KRINGLE_DOMAIN));
+        assertThat(subject.getTermName(IPR000001), is(Optional.of(KRINGLE_DOMAIN)));
     }
 
     @Test
     public void hasLastTerm() {
-        assertThat(subject.getTermName(IPR029787), is(NUCLEOTIDE_CYCLASE_DOMAIN));
+        assertThat(subject.getTermName(IPR029787), is(Optional.of(NUCLEOTIDE_CYCLASE_DOMAIN)));
     }
 
     @Test
     public void unknownTermsReturnNull() {
-        assertThat(subject.getTermName("IPRFOOBAR"), is(nullValue()));
+        assertThat(subject.getTermName("IPRFOOBAR"), is(Optional.empty()));
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/utils/ReactomeClientEIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/utils/ReactomeClientEIT.java
@@ -7,6 +7,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -20,12 +22,12 @@ public class ReactomeClientEIT {
 
     @Test
     public void parseReactomeId() throws Exception {
-        assertThat(subject.fetchPathwayNameFailSafe("R-HSA-15869"), is("Metabolism of nucleotides"));
-        assertThat(subject.fetchPathwayNameFailSafe("R-HSA-73887"), is("Death Receptor Signalling"));
+        assertThat(subject.fetchPathwayNameFailSafe("R-HSA-15869"), is(Optional.of("Metabolism of nucleotides")));
+        assertThat(subject.fetchPathwayNameFailSafe("R-HSA-73887"), is(Optional.of("Death Receptor Signalling")));
     }
 
     @Test
     public void unmatchedIdReturnsNull() throws Exception {
-        assertThat(subject.fetchPathwayNameFailSafe("foobar"), is(nullValue()));
+        assertThat(subject.fetchPathwayNameFailSafe("foobar"), is(Optional.empty()));
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/utils/ReactomeClientTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/utils/ReactomeClientTest.java
@@ -7,7 +7,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import static org.hamcrest.Matchers.isEmptyString;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -26,6 +28,6 @@ public class ReactomeClientTest {
       when(restTemplateMock.getForObject(anyString(), any())).thenThrow(new RestClientException("Timeout!"));
       subject = new ReactomeClient(restTemplateMock);
 
-      assertThat(subject.fetchPathwayNameFailSafe("foobar"), isEmptyString());
+      assertThat(subject.fetchPathwayNameFailSafe("foobar"), is(Optional.empty()));
   }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/utils/ReactomeClientTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/utils/ReactomeClientTest.java
@@ -1,0 +1,31 @@
+package uk.ac.ebi.atlas.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReactomeClientTest {
+
+  @Mock
+  RestTemplate restTemplateMock;
+
+  ReactomeClient subject;
+
+  @Test
+  public void returnEmptyStringIfRestTemplateThrows() throws Exception {
+      when(restTemplateMock.getForObject(anyString(), any())).thenThrow(new RestClientException("Timeout!"));
+      subject = new ReactomeClient(restTemplateMock);
+
+      assertThat(subject.fetchPathwayNameFailSafe("foobar"), isEmptyString());
+  }
+}

--- a/gxa/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/gxa/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -27,8 +27,8 @@
     <bean id="restTemplate" class="org.springframework.web.client.RestTemplate">
         <constructor-arg>
             <bean class="org.springframework.http.client.SimpleClientHttpRequestFactory"
-                  p:readTimeout="120000"
-                  p:connectTimeout="120000" />
+                  p:readTimeout="20000"
+                  p:connectTimeout="20000" />
         </constructor-arg>
     </bean>
 

--- a/gxa/src/test/resources/dispatcher-servlet.xml
+++ b/gxa/src/test/resources/dispatcher-servlet.xml
@@ -27,8 +27,8 @@
     <bean id="restTemplate" class="org.springframework.web.client.RestTemplate">
         <constructor-arg>
             <bean class="org.springframework.http.client.SimpleClientHttpRequestFactory"
-                  p:readTimeout="120000"
-                  p:connectTimeout="120000" />
+                  p:readTimeout="20000"
+                  p:connectTimeout="20000" />
         </constructor-arg>
     </bean>
 

--- a/sc/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/sc/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -28,8 +28,8 @@
     <bean id="restTemplate" class="org.springframework.web.client.RestTemplate">
         <constructor-arg>
             <bean class="org.springframework.http.client.SimpleClientHttpRequestFactory"
-                  p:readTimeout="120000"
-                  p:connectTimeout="120000" />
+                  p:readTimeout="20000"
+                  p:connectTimeout="20000" />
         </constructor-arg>
     </bean>
 

--- a/sc/src/test/resources/dispatcher-servlet.xml
+++ b/sc/src/test/resources/dispatcher-servlet.xml
@@ -27,8 +27,8 @@
     <bean id="restTemplate" class="org.springframework.web.client.RestTemplate">
         <constructor-arg>
             <bean class="org.springframework.http.client.SimpleClientHttpRequestFactory"
-                  p:readTimeout="120000"
-                  p:connectTimeout="120000" />
+                  p:readTimeout="20000"
+                  p:connectTimeout="20000" />
         </constructor-arg>
     </bean>
 


### PR DESCRIPTION
There’s a timeout error if we query Reactome API using HTTPS, it works fine over HTTP. It works well on my laptop, so it’s an environment issue (it fails also in `lime`), so I’m inclined to think it has something to do with the EBI proxy servers.

In any case, if something wrong happens in `ReactomeClient`, would you rather return an empty string or something along the lines of *There was an error accessing Reactome, please try again later*? The problem with the latter is that it could give the impression that Reactome is failing when it is not... anyway, suggestions welcome!