### PR TITLE
Bugfix #157046869 - Maintain sdrf column ordering in experiment design

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrud.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrud.java
@@ -96,6 +96,7 @@ public class ExperimentCrud {
 
         UUID accessKeyUuid = accessKey.map(UUID::fromString).orElseGet(UUID::randomUUID);
         experimentDao.addExperiment(experimentDTO, accessKeyUuid);
+
         updateWithNewExperimentDesign(condensedSdrfParserOutput.getExperimentDesign(), experimentDTO);
 
         return accessKeyUuid;
@@ -199,16 +200,10 @@ public class ExperimentCrud {
     }
 
     private void updateWithNewExperimentDesign(ExperimentDesign newDesign, ExperimentDTO experimentDTO) {
-        updateWithNewExperimentDesign(
-                experimentDTO.getExperimentAccession(), experimentDTO.getExperimentType(), newDesign);
-
-    }
-
-    private void updateWithNewExperimentDesign(String accession, ExperimentType type,
-                                               ExperimentDesign experimentDesign) {
         try {
-            experimentDesignFileWriterService.writeExperimentDesignFile(accession, type, experimentDesign);
-            LOGGER.info("updated design for experiment {}", accession);
+            experimentDesignFileWriterService.writeExperimentDesignFile(experimentDTO.getExperimentAccession(),
+                    experimentDTO.getExperimentType(), newDesign);
+            LOGGER.info("updated design for experiment {}", experimentDTO.getExperimentAccession());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/experimentdesign/ExperimentDesignFileWriter.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/experimentdesign/ExperimentDesignFileWriter.java
@@ -57,7 +57,7 @@ public class ExperimentDesignFileWriter {
         return headers.toArray(new String[0]);
     }
 
-    private List<String> toHeaders(SortedSet<String> propertyNames,
+    private List<String> toHeaders(Set<String> propertyNames,
                                    final String headerTemplate1,
                                    final String headerTemplate2) {
         List<String> headers = new ArrayList<>();

--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
@@ -1,0 +1,55 @@
+package uk.ac.ebi.atlas.experimentimport.sdrf;
+
+import uk.ac.ebi.atlas.commons.readers.TsvStreamer;
+import uk.ac.ebi.atlas.resource.DataFileHub;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Named
+public class SdrfParser {
+
+    private final DataFileHub dataFileHub;
+
+    @Inject
+    public SdrfParser(DataFileHub dataFileHub) {
+        this.dataFileHub = dataFileHub;
+    }
+
+    // Returns a map containing the header values for characteristics and factors
+    public Map<String, List<String>> parseHeader(String experimentAccession) {
+        try (TsvStreamer sdrfStreamer = dataFileHub.getExperimentFiles(experimentAccession).sdrf.get()) {
+            Pattern pattern = Pattern.compile("(.*?)(\\[)(.*?)(].*)");
+
+            Map<String, List<String>> headers = new HashMap<>();
+            Arrays.stream(
+                    sdrfStreamer
+                            .get()
+                            .findFirst()
+                            .orElse(new String[0]))
+                    .filter(x -> x.toLowerCase().contains("characteristic") || x.toLowerCase().contains("factor"))
+                    .forEach(header -> {
+                        Matcher matcher = pattern.matcher(header);
+                        if (matcher.matches()) {
+                            String headerType = matcher.group(1).trim().toLowerCase(); // is the header a characteristic or a factor value?
+                            String headerValue = matcher.group(3); // what is the title of the header? e.g. organism, age, etc
+                            if (headers.containsKey(headerType)) {
+                                headers.get(headerType).add(headerValue);
+                            } else {
+                                List<String> headerValues = new ArrayList<>();
+                                headerValues.add(headerValue);
+                                headers.put(headerType, headerValues);
+                            }
+                        }
+                    });
+            return headers;
+        }
+    }
+}

--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
@@ -24,9 +24,13 @@ public class SdrfParser {
         this.dataFileHub = dataFileHub;
     }
 
-    // Returns a map containing the header values for characteristics and factors
+    /**
+     * Returns a map containing the header values for characteristics and factors, maintaining the same order in
+     * which they appear in the sdrf file.
+     */
     public Map<String, Set<String>> parseHeader(String experimentAccession) {
         try (TsvStreamer sdrfStreamer = dataFileHub.getExperimentFiles(experimentAccession).sdrf.get()) {
+            // Headers of interest are of the form HeaderType[HeaderValue]
             Pattern pattern = Pattern.compile("(.*?)(\\[)(.*?)(].*)");
 
             Map<String, Set<String>> headers = new HashMap<>();
@@ -39,8 +43,10 @@ public class SdrfParser {
                     .forEach(header -> {
                         Matcher matcher = pattern.matcher(header);
                         if (matcher.matches()) {
-                            String headerType = StringUtils.trimAllWhitespace(matcher.group(1)).toLowerCase(); // is the header a characteristic or a factor value?
-                            String headerValue = matcher.group(3).trim().toLowerCase(); // what is the title of the header? e.g. organism, age, etc
+                            // The header is either a characteristic or a factor value
+                            String headerType = StringUtils.trimAllWhitespace(matcher.group(1)).toLowerCase();
+                            // The title of the header is a type of metadata, such as organism, age, etc
+                            String headerValue = matcher.group(3).trim().toLowerCase();
                             if (headers.containsKey(headerType)) {
                                 headers.get(headerType).add(headerValue);
                             } else {

--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
@@ -1,15 +1,16 @@
 package uk.ac.ebi.atlas.experimentimport.sdrf;
 
+import org.springframework.util.StringUtils;
 import uk.ac.ebi.atlas.commons.readers.TsvStreamer;
 import uk.ac.ebi.atlas.resource.DataFileHub;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,11 +25,11 @@ public class SdrfParser {
     }
 
     // Returns a map containing the header values for characteristics and factors
-    public Map<String, List<String>> parseHeader(String experimentAccession) {
+    public Map<String, Set<String>> parseHeader(String experimentAccession) {
         try (TsvStreamer sdrfStreamer = dataFileHub.getExperimentFiles(experimentAccession).sdrf.get()) {
             Pattern pattern = Pattern.compile("(.*?)(\\[)(.*?)(].*)");
 
-            Map<String, List<String>> headers = new HashMap<>();
+            Map<String, Set<String>> headers = new HashMap<>();
             Arrays.stream(
                     sdrfStreamer
                             .get()
@@ -38,12 +39,12 @@ public class SdrfParser {
                     .forEach(header -> {
                         Matcher matcher = pattern.matcher(header);
                         if (matcher.matches()) {
-                            String headerType = matcher.group(1).trim().toLowerCase(); // is the header a characteristic or a factor value?
-                            String headerValue = matcher.group(3); // what is the title of the header? e.g. organism, age, etc
+                            String headerType = StringUtils.trimAllWhitespace(matcher.group(1)).toLowerCase(); // is the header a characteristic or a factor value?
+                            String headerValue = matcher.group(3).trim().toLowerCase(); // what is the title of the header? e.g. organism, age, etc
                             if (headers.containsKey(headerType)) {
                                 headers.get(headerType).add(headerValue);
                             } else {
-                                List<String> headerValues = new ArrayList<>();
+                                Set<String> headerValues = new LinkedHashSet<>();
                                 headerValues.add(headerValue);
                                 headers.put(headerType, headerValues);
                             }

--- a/base/src/main/java/uk/ac/ebi/atlas/model/analyticsindex/DifferentialExperimentDataPointStream.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/analyticsindex/DifferentialExperimentDataPointStream.java
@@ -12,6 +12,7 @@ import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/base/src/main/java/uk/ac/ebi/atlas/model/analyticsindex/MicroarrayExperimentDataPointStream.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/analyticsindex/MicroarrayExperimentDataPointStream.java
@@ -14,6 +14,7 @@ import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperi
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/base/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
@@ -2,9 +2,8 @@ package uk.ac.ebi.atlas.model.experiment;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.springframework.util.CollectionUtils;
 import uk.ac.ebi.atlas.model.OntologyTerm;
 import uk.ac.ebi.atlas.model.SampleCharacteristic;
 import uk.ac.ebi.atlas.model.experiment.baseline.Factor;
@@ -12,9 +11,11 @@ import uk.ac.ebi.atlas.model.experiment.baseline.impl.FactorSet;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,20 +36,24 @@ import java.util.SortedSet;
  */
 public class ExperimentDesign implements Serializable {
 
-    private SortedSet<String> sampleHeaders = Sets.newTreeSet();
-    private SortedSet<String> factorHeaders = Sets.newTreeSet();
+    // Headers retrieved from the condensed sdrf file
+    private Set<String> sampleHeaders = new LinkedHashSet<>();
+    private Set<String> factorHeaders = new LinkedHashSet<>();
+
+    // Headers retrieved from the sdrf file, which maintain a curated order
+    private Set<String> orderedSampleHeaders;
+    private Set<String> orderedFactorHeaders;
 
     // assay, SampleCharacteristics
-    private Map<String, SampleCharacteristics> samples = Maps.newHashMap();
+    private Map<String, SampleCharacteristics> samples = new HashMap<>();
 
     // header, value
     private class SampleCharacteristics extends HashMap<String, SampleCharacteristic> { }
 
     // assay, factors
-    private Map<String, FactorSet> factorSetMap = Maps.newHashMap();
-    private Map<String, String> arrayDesigns = Maps.newHashMap();
-    private List<String> assayHeaders = Lists.newArrayList();
-
+    private Map<String, FactorSet> factorSetMap = new HashMap<>();
+    private Map<String, String> arrayDesigns = new HashMap<>();
+    private List<String> assayHeaders = new ArrayList<>();
 
     public void putSampleCharacteristic(String runOrAssay,
                                         String sampleCharacteristicHeader,
@@ -102,20 +107,34 @@ public class ExperimentDesign implements Serializable {
         assayHeaders.add(assayHeader);
     }
 
+    public void setOrderedSampleHeaders(Set<String> orderedSampleHeaders) {
+        this.orderedSampleHeaders = orderedSampleHeaders;
+    }
+
+    public void setOrderedFactorHeaders(Set<String> orderedFactorHeaders) {
+        this.orderedFactorHeaders = orderedFactorHeaders;
+    }
 
     public List<String> getAssayHeaders() {
         return assayHeaders;
     }
 
-
-    public SortedSet<String> getSampleHeaders() {
-        return Collections.unmodifiableSortedSet(sampleHeaders);
+    public Set<String> getSampleHeaders() {
+        if (!CollectionUtils.isEmpty(orderedSampleHeaders)) {
+            return Collections.unmodifiableSet(orderedSampleHeaders);
+        } else {
+            return Collections.unmodifiableSet(sampleHeaders);
+        }
     }
 
 
     //NB: factor headers are not normalized (see Factor.normalize), unlike factor type !
-    public SortedSet<String> getFactorHeaders() {
-        return Collections.unmodifiableSortedSet(factorHeaders);
+    public Set<String> getFactorHeaders() {
+        if (!CollectionUtils.isEmpty(orderedFactorHeaders)) {
+            return Collections.unmodifiableSet(orderedFactorHeaders);
+        } else {
+            return Collections.unmodifiableSet(factorHeaders);
+        }
     }
 
 

--- a/base/src/main/java/uk/ac/ebi/atlas/model/experiment/summary/ContrastSummaryBuilder.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/experiment/summary/ContrastSummaryBuilder.java
@@ -7,8 +7,10 @@ import com.google.common.collect.Sets;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.differential.Contrast;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -65,7 +67,7 @@ public class ContrastSummaryBuilder {
         }
 
         // array design row should be sorted within samples category
-        SortedSet<String> sampleHeaders = Sets.newTreeSet(experimentDesign.getSampleHeaders());
+        List<String> sampleHeaders = new ArrayList<>(experimentDesign.getSampleHeaders());
         sampleHeaders.add(ARRAY_DESIGN);
         for (String sampleHeader : sampleHeaders) {
             ContrastProperty property =

--- a/base/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
@@ -83,7 +83,6 @@ public class DataFileHub {
             SINGLE_CELL_MATRIX_MARKET_FILTERED_AGGREGATED_COUNTS_FILE_PATH_TEMPLATE + "_cols";
 
     protected static final String SINGLE_CELL_T_SNE_PLOT_FILE_PATH_TEMPLATE = "{0}/{0}.tsne_perp_{1}.tsv";
-    protected static final String SINGLE_CELL_SDRF_FILE_PATH_TEMPLATE = "{0}/{0}.sdrf.txt";
     protected static final String SINGLE_CELL_CLUSTERS_FILE_PATH_TEMPLATE = "{0}/{0}.clusters.tsv";
     protected static final String SINGLE_CELL_SOFTWARE_USED_FILE_PATH_TEMPLATE = "{0}/{0}.software.tsv";
 
@@ -354,7 +353,6 @@ public class DataFileHub {
         public final AtlasResource<MatrixMarketReader> tpmsMatrix;
         public final AtlasResource<TsvStreamer> geneIdsTsv;
         public final AtlasResource<TsvStreamer> cellIdsTsv;
-        public final AtlasResource<TsvStreamer> sdrf;
         public final AtlasResource<TsvStreamer> clustersTsv;
         public final Map<Integer, AtlasResource<TsvStreamer>> tSnePlotTsvs;
 
@@ -364,11 +362,6 @@ public class DataFileHub {
             softwareUsed = new TsvFile.ReadOnly(
                     experimentsMageTabDirLocation,
                     SINGLE_CELL_SOFTWARE_USED_FILE_PATH_TEMPLATE,
-                    experimentAccession);
-
-            sdrf = new TsvFile.ReadOnly(
-                    experimentsMageTabDirLocation,
-                    SINGLE_CELL_SDRF_FILE_PATH_TEMPLATE,
                     experimentAccession);
 
             clustersTsv = new TsvFile.ReadOnly(

--- a/base/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
@@ -40,6 +40,7 @@ public class DataFileHub {
     protected static final String CONFIGURATION_FILE_PATH_TEMPLATE = "{0}/{0}-configuration.xml";
     static final String ANALYSIS_METHODS_FILE_PATH_TEMPLATE = "{0}/{0}-analysis-methods.tsv";
     protected static final String CONDENSED_SDRF_FILE_PATH_TEMPLATE = "{0}/{0}.condensed-sdrf.tsv";
+    protected static final String SDRF_FILE_PATH_TEMPLATE = "{0}/{0}.sdrf.txt";
     protected static final String IDF_FILE_PATH_TEMPLATE = "{0}/{0}.idf.txt";
 
     protected static final String PROTEOMICS_BASELINE_EXPRESSION_FILE_PATH_TEMPLATE = "{0}/{0}.tsv";
@@ -134,6 +135,7 @@ public class DataFileHub {
         public final AtlasResource<TsvStreamer> analysisMethods;
         public final AtlasResource<XmlReader> configuration;
         public final AtlasResource<TsvStreamer> condensedSdrf;
+        public final AtlasResource<TsvStreamer> sdrf;
         public final AtlasResource<TsvStreamer> idf;
         public final AtlasResource<Set<Path>> qcFolder;
         public final AtlasResource<TsvStreamer> experimentDesign;
@@ -151,6 +153,11 @@ public class DataFileHub {
             condensedSdrf =
                     new TsvFile.ReadOnly(
                             experimentsMageTabDirLocation, CONDENSED_SDRF_FILE_PATH_TEMPLATE, experimentAccession);
+
+            sdrf =
+                    new TsvFile.ReadOnly(
+                            experimentsMageTabDirLocation, SDRF_FILE_PATH_TEMPLATE, experimentAccession);
+
             idf =
                     new TsvFile.ReadOnly(
                             experimentsMageTabDirLocation, IDF_FILE_PATH_TEMPLATE, experimentAccession);

--- a/base/src/main/java/uk/ac/ebi/atlas/testutils/MockDataFileHub.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/testutils/MockDataFileHub.java
@@ -138,6 +138,13 @@ public final class MockDataFileHub extends DataFileHub {
                 lines);
     }
 
+    public void addSdrfFile(String accession, Collection<String[]> lines) {
+        addTemporaryTsv(
+                experimentsMageTabDirLocation.resolve(
+                        MessageFormat.format(SDRF_FILE_PATH_TEMPLATE, accession)),
+                lines);
+    }
+
     public void addIdfFile(String accession, Collection<String[]> lines) {
         addTemporaryTsv(
                 experimentsMageTabDirLocation.resolve(

--- a/base/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
@@ -28,7 +29,7 @@ public class ExperimentInfo implements Comparable<ExperimentInfo> {
     private int numberOfContrasts;
     private String species;
     private String kingdom;
-    private SortedSet<String> experimentalFactors = Sets.newTreeSet();
+    private List<String> experimentalFactors = new ArrayList<>();
     private List<String> arrayDesigns = ImmutableList.of();
     private List<String> arrayDesignNames = ImmutableList.of();
 
@@ -88,12 +89,12 @@ public class ExperimentInfo implements Comparable<ExperimentInfo> {
         this.kingdom = kingdom;
     }
 
-    public SortedSet<String> getExperimentalFactors() {
+    public List<String> getExperimentalFactors() {
         return experimentalFactors;
     }
 
     public void setExperimentalFactors(Set<String> experimentalFactors) {
-        this.experimentalFactors = Sets.newTreeSet(experimentalFactors);
+        this.experimentalFactors = new ArrayList<>(experimentalFactors);
     }
 
     public List<String> getArrayDesigns() {

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrudTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrudTest.java
@@ -13,6 +13,7 @@ import uk.ac.ebi.atlas.experimentimport.condensedSdrf.CondensedSdrfParserOutput;
 import uk.ac.ebi.atlas.experimentimport.experimentdesign.ExperimentDesignFileWriterService;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
+import uk.ac.ebi.atlas.experimentimport.sdrf.SdrfParser;
 import uk.ac.ebi.atlas.model.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.ExperimentConfiguration;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
@@ -47,6 +48,9 @@ public class ExperimentCrudTest {
 
     @Mock
     private CondensedSdrfParser condensedSdrfParserMock;
+
+    @Mock
+    private SdrfParser sdrfParserMock;
 
     @Mock
     private IdfParser idfParserMock;

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParserTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParserTest.java
@@ -20,10 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -100,13 +97,12 @@ public class CondensedSdrfParserTest {
     };
 
     private static final String[][] E_MTAB_513_SDRF_HEADER_MISSING_CHARACTERISTIC = {{
-            createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, ORGANISM),
-            createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, AGE),
-            createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, ETHNIC_GROUP),
-            createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, ORGANISM_PART),
-            createSdrfHeaderString(FACTOR_HEADER_TYPE, ORGANISM_PART)}
+        createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, ORGANISM),
+        createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, AGE),
+        createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, ETHNIC_GROUP),
+        createSdrfHeaderString(CHARACTERISTIC_HEADER_TYPE, ORGANISM_PART),
+        createSdrfHeaderString(FACTOR_HEADER_TYPE, ORGANISM_PART)}
     };
-
 
     private static final String E_MEXP_1810 = "E-MEXP-1810";
     private static final String H_RIL_14_NON_DAUER_1 = "H_RIL-14 non-dauer 1";
@@ -162,7 +158,7 @@ public class CondensedSdrfParserTest {
     }
 
     @Test
-    public void parse() {
+    public void parseWhenSdrfIsPresent() {
         dataFileHub.addCondensedSdrfFile(E_MTAB_513, Arrays.asList(E_MTAB_513_CONDENSED_SDRF_ARRAY));
         dataFileHub.addSdrfFile(E_MTAB_513, Arrays.asList(E_MTAB_513_SDRF_HEADER_ARRAY));
 
@@ -172,41 +168,45 @@ public class CondensedSdrfParserTest {
         ));
 
         CondensedSdrfParserOutput output = subject.parse(E_MTAB_513, ExperimentType.RNASEQ_MRNA_BASELINE);
-        assertThat(
-                output.getExperimentAccession(),
-                is(E_MTAB_513));
-        assertThat(
-                output.getExperimentType(),
-                is(ExperimentType.RNASEQ_MRNA_BASELINE));
+        assertThat(output.getExperimentAccession())
+                .isEqualTo(E_MTAB_513);
+        assertThat(output.getExperimentType())
+                .isEqualByComparingTo(ExperimentType.RNASEQ_MRNA_BASELINE);
 
         ExperimentDesign experimentDesign = output.getExperimentDesign();
-        assertThat(
-                experimentDesign.getFactorHeaders(),
-                hasItems(ORGANISM_PART));
-        assertThat(
-                experimentDesign.getAllRunOrAssay(),
-                containsInAnyOrder(ASSAYS));
-        assertThat(
-                experimentDesign.getFactorHeaders(),
-                containsInAnyOrder(ORGANISM_PART));
-        assertThat(
-                experimentDesign.getFactors(ASSAYS[0]).size(),
-                is(1));
-        assertThat(
-                experimentDesign.getSampleHeaders(),
-                containsInAnyOrder(AGE, ORGANISM_PART, ETHNIC_GROUP, SEX, ORGANISM));
-        assertThat(
-                experimentDesign.getSampleCharacteristic(ASSAYS[2], ETHNIC_GROUP).value(),
-                is(AFRICAN_AMERICAN));
-        assertThat(
-                experimentDesign.getSampleCharacteristics(ASSAYS[0]).size(),
-                is(4));
-        assertThat(
-                experimentDesign.getSampleCharacteristics(ASSAYS[3]).size(),
-                is(5));
-        assertThat(
-                output.getSpecies(),
-                is(HOMO_SAPIENS));
+        assertThat(experimentDesign.getAllRunOrAssay())
+                .containsExactlyInAnyOrder(ASSAYS);
+        assertThat(experimentDesign.getFactorHeaders())
+                .containsExactly(ORGANISM_PART);
+        assertThat(experimentDesign.getFactors(ASSAYS[0]).size())
+                .isEqualTo(1);
+        // The headers are in the order in which they are found in the sdrf
+        assertThat(experimentDesign.getSampleHeaders())
+                .containsExactly(ORGANISM, AGE, SEX, ETHNIC_GROUP, ORGANISM_PART);
+        assertThat(experimentDesign.getSampleCharacteristic(ASSAYS[2], ETHNIC_GROUP).value())
+                .isEqualTo(AFRICAN_AMERICAN);
+        assertThat(experimentDesign.getSampleCharacteristics(ASSAYS[0]).size())
+                .isEqualTo(4);
+        assertThat(experimentDesign.getSampleCharacteristics(ASSAYS[3]).size())
+                .isEqualTo(5);
+        assertThat(output.getSpecies())
+                .isEqualTo(HOMO_SAPIENS);
+    }
+
+    @Test
+    public void parseWhenSdrfIsAbsent() {
+        dataFileHub.addCondensedSdrfFile(E_MTAB_513, Arrays.asList(E_MTAB_513_CONDENSED_SDRF_ARRAY));
+
+        CondensedSdrfParserOutput output = subject.parse(E_MTAB_513, ExperimentType.RNASEQ_MRNA_BASELINE);
+        assertThat(output.getExperimentAccession())
+                .isEqualTo(E_MTAB_513);
+
+        ExperimentDesign experimentDesign = output.getExperimentDesign();
+        assertThat(experimentDesign.getFactorHeaders())
+                .containsExactly(ORGANISM_PART);
+        // If no sdrf file is present, the ordering of the headers will be alphabetic
+        assertThat(experimentDesign.getSampleHeaders())
+                .containsExactly(AGE, ETHNIC_GROUP, ORGANISM, ORGANISM_PART, SEX);
     }
 
     @Test
@@ -226,12 +226,10 @@ public class CondensedSdrfParserTest {
         CondensedSdrfParserOutput output = subject.parse(E_MTAB_513, ExperimentType.RNASEQ_MRNA_BASELINE);
 
         ExperimentDesign experimentDesign = output.getExperimentDesign();
-        assertThat(
-                experimentDesign.getAllRunOrAssay(),
-                containsInAnyOrder(ASSAYS[0], ASSAYS[1], ASSAYS[2]));
-        assertThat(
-                experimentDesign.getSampleHeaders(),
-                containsInAnyOrder(AGE, ORGANISM_PART, ETHNIC_GROUP, ORGANISM));
+        assertThat(experimentDesign.getAllRunOrAssay())
+                .containsExactlyInAnyOrder(ASSAYS[0], ASSAYS[1], ASSAYS[2]);
+        assertThat(experimentDesign.getSampleHeaders())
+                .containsExactly(ORGANISM, AGE, ETHNIC_GROUP, ORGANISM_PART);
     }
 
     @Test
@@ -241,9 +239,8 @@ public class CondensedSdrfParserTest {
         CondensedSdrfParserOutput output = subject.parse(E_MEXP_1810, ExperimentType.RNASEQ_MRNA_BASELINE);
 
         ExperimentDesign experimentDesign = output.getExperimentDesign();
-        assertThat(
-                experimentDesign.getFactor(H_RIL_14_NON_DAUER_1, "compound").getValue(),
-                is(COMPOUND_VALUE + " " + DOSE_VALUE));
+        assertThat(experimentDesign.getFactor(H_RIL_14_NON_DAUER_1, "compound").getValue())
+                .isEqualTo(COMPOUND_VALUE + " " + DOSE_VALUE);
     }
 
     @Test
@@ -255,7 +252,8 @@ public class CondensedSdrfParserTest {
         CondensedSdrfParserOutput output = subject.parse(E_MEXP_1810, ExperimentType.RNASEQ_MRNA_BASELINE);
 
         ExperimentDesign experimentDesign = output.getExperimentDesign();
-        assertThat(experimentDesign.getFactor(H_RIL_14_NON_DAUER_1, "compound").getValue(), is(COMPOUND_VALUE));
+        assertThat(experimentDesign.getFactor(H_RIL_14_NON_DAUER_1, "compound").getValue())
+                .isEqualTo(COMPOUND_VALUE);
     }
 
     @Test

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
@@ -1,0 +1,76 @@
+package uk.ac.ebi.atlas.experimentimport.sdrf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.testutils.MockDataFileHub;
+import uk.ac.ebi.atlas.testutils.RandomDataTestUtils;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SdrfParserTest {
+
+    private static final String CHARACTERISTICS = "characteristics";
+    private static final String FACTORS = "factorvalue";
+
+    private static final String[][] SDRF_TXT_MIXED_SPACING = {
+            {"Source Name", "Characteristics [organism]", "Characteristics[developmental stage]", "Characteristics [organism part]", "Factor Value[organism part]", "FactorValue [organism]"},
+            {"first_source", "homo sapiens", "adult", "liver", "liver", "homo sapiens"}
+    };
+
+    private static final String[][] SDRF_TXT_NO_FACTORS = {
+            {"Source Name", "Characteristics [organism]", "Characteristics[developmental stage]", "Characteristics [organism part]"},
+            {"first_source", "homo sapiens", "adult", "liver"}
+    };
+
+    private MockDataFileHub dataFileHub;
+
+    private SdrfParser subject;
+
+    @BeforeEach
+    void setUp() {
+        dataFileHub = MockDataFileHub.create();
+
+        subject = new SdrfParser(dataFileHub);
+    }
+
+    @Test
+    void parseHeaderWithCharacteristicsAndFactors() {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+
+        dataFileHub.addSdrfFile(experimentAccession, Arrays.asList(SDRF_TXT_MIXED_SPACING));
+
+        Map<String, Set<String>> result = subject.parseHeader(experimentAccession);
+
+        assertThat(result)
+                .hasSize(2)
+                .containsOnlyKeys(CHARACTERISTICS, FACTORS);
+
+        assertThat(result.get(CHARACTERISTICS))
+                .containsExactly("organism", "developmental stage", "organism part");
+
+        assertThat(result.get(FACTORS))
+                .containsExactly("organism part", "organism");
+    }
+
+    @Test
+    void parseHeaderWithCharacteristicsOnly() {
+        String experimentAccession = RandomDataTestUtils.getRandomExperimentAccession();
+
+        dataFileHub.addSdrfFile(experimentAccession, Arrays.asList(SDRF_TXT_NO_FACTORS));
+
+        Map<String, Set<String>> result = subject.parseHeader(experimentAccession);
+
+        assertThat(result)
+                .hasSize(1)
+                .containsOnlyKeys(CHARACTERISTICS)
+                .doesNotContainKeys(FACTORS);
+
+        assertThat(result.get(CHARACTERISTICS))
+                .containsExactly("organism", "developmental stage", "organism part");
+    }
+
+}

--- a/base/src/test/java/uk/ac/ebi/atlas/trader/ExperimentDesignParserTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/trader/ExperimentDesignParserTest.java
@@ -7,7 +7,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.ac.ebi.atlas.experimentimport.sdrf.SdrfParser;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.testutils.MockDataFileHub;
 
@@ -70,6 +72,9 @@ public class ExperimentDesignParserTest {
 
     private static MockDataFileHub dataFileHub;
 
+    @Mock
+    private SdrfParser mockSdrfParser;
+
     private ExperimentDesignParser subject;
 
     @BeforeClass
@@ -80,7 +85,7 @@ public class ExperimentDesignParserTest {
     @Before
     public void setUp() {
         dataFileHub.addExperimentDesignFile(EXPERIMENT_ACCESSION, DATA);
-        subject = new ExperimentDesignParser(dataFileHub);
+        subject = new ExperimentDesignParser(dataFileHub, mockSdrfParser);
     }
 
     @Test

--- a/base/src/test/java/uk/ac/ebi/atlas/trader/ExperimentDesignParserWithOntologyTermsTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/trader/ExperimentDesignParserWithOntologyTermsTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import uk.ac.ebi.atlas.experimentimport.sdrf.SdrfParser;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.OntologyTerm;
 import uk.ac.ebi.atlas.model.SampleCharacteristic;
@@ -103,6 +104,7 @@ public class ExperimentDesignParserWithOntologyTermsTest {
             new Factor(GENOTYPE, CYC);
 
     private static MockDataFileHub dataFileHub;
+    private SdrfParser sdrfParserMock;
 
     private ExperimentDesignParser subject;
 
@@ -116,7 +118,7 @@ public class ExperimentDesignParserWithOntologyTermsTest {
 
         dataFileHub.addExperimentDesignFile(EXPERIMENT_ACCESSION, DATA);
 
-        subject = new ExperimentDesignParser(dataFileHub);
+        subject = new ExperimentDesignParser(dataFileHub, sdrfParserMock);
     }
 
     @Test

--- a/gxa/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentInfoListServiceTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentInfoListServiceTest.java
@@ -27,9 +27,11 @@ import uk.ac.ebi.atlas.species.SpeciesProperties;
 import uk.ac.ebi.atlas.trader.ExpressionAtlasExperimentTrader;
 import uk.ac.ebi.atlas.utils.ExperimentInfo;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -129,7 +131,7 @@ public class ExperimentInfoListServiceTest {
         }).when(experimentTraderMock).getPublicExperiments(any());
 
         //call real method on big method, small one takes from this map
-        when(experimentDesignMock.getFactorHeaders()).thenReturn(Sets.newTreeSet(Sets.newHashSet(FACTOR_NAME)));
+        when(experimentDesignMock.getFactorHeaders()).thenReturn(new LinkedHashSet<>(Collections.singletonList(FACTOR_NAME)));
 
         subject = new ExperimentInfoListService(experimentTraderMock, ImmutableList.of(baselineExperiment.getType(),
                 differentialExperiment.getType(), microarrayExperiment.getType()));

--- a/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentsCacheLoaderIT.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/trader/cache/loader/ProteomicsBaselineExperimentsCacheLoaderIT.java
@@ -144,7 +144,7 @@ public class ProteomicsBaselineExperimentsCacheLoaderIT {
         ExperimentDesign experimentDesign = experiment.getExperimentDesign();
 
         assertThat(experimentDesign.getFactorHeaders(), contains(DEVELOPMENTAL_STAGE, ORGANISM_PART));
-        assertThat(experimentDesign.getSampleHeaders(), contains(DEVELOPMENTAL_STAGE, ORGANISM, ORGANISM_PART));
+        assertThat(experimentDesign.getSampleHeaders(), contains(ORGANISM, DEVELOPMENTAL_STAGE, ORGANISM_PART));
 
         Iterator<SampleCharacteristic> sampleCharacteristicIterator =
                 experimentDesign.getSampleCharacteristics("Adult_Ovary").iterator();

--- a/sc/src/main/java/uk/ac/ebi/atlas/download/ExperimentFileLocationService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/download/ExperimentFileLocationService.java
@@ -30,7 +30,7 @@ public class ExperimentFileLocationService {
                         .getSingleCellExperimentFiles(experimentAccession)
                         .experimentFiles.experimentDesign.getPath();
             case SDRF:
-                return dataFileHub.getSingleCellExperimentFiles(experimentAccession).sdrf.getPath();
+                return dataFileHub.getSingleCellExperimentFiles(experimentAccession).experimentFiles.sdrf.getPath();
             case IDF:
                 return dataFileHub.getSingleCellExperimentFiles(experimentAccession).experimentFiles.idf.getPath();
             case CLUSTERING:


### PR DESCRIPTION
- Added sdrf parser class that can parse the header of the file and retrieve characteristics and factors, preserving the column ordering
- Added additional logic to the condensed sdrf parser to parse the sdrf (when available), in order to provide the ordered characteristics/factors to the ExperimentDesign class
- Added tests
- Converted `CondensedSdrfParserTest` to AssertJ assertions