### PR TITLE
Bugfix - Some experiment titles are wrong

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParser.java
@@ -58,23 +58,10 @@ public class IdfParser {
                                             .collect(Collectors.toList()),
                                     (accumulatedValues, newValue) -> accumulatedValues));
 
-            String title;
-            // Experiments that are regularly updated in ArrayExpress
-            if (experimentAccession.startsWith("E-MTAB") || experimentAccession.startsWith("E-TABM")) {
-                 title =
-                         getParsedOutputByKey(
-                                 AE_EXPERIMENT_DISPLAY_NAME_ID,
-                                 getParsedOutputByKey(INVESTIGATION_TITLE_ID, emptyList()))
-                                 .stream()
-                                 .filter(StringUtils::isNotBlank)
-                                 .findFirst()
-                                 .orElse("");
-            } else {
-                title = getParsedOutputByKey(INVESTIGATION_TITLE_ID, emptyList())
-                        .stream()
-                        .findFirst()
-                        .orElse("");
-            }
+            String title = getParsedOutputByKey(AE_EXPERIMENT_DISPLAY_NAME_ID, getParsedOutputByKey(INVESTIGATION_TITLE_ID, emptyList()))
+                    .stream()
+                    .findFirst()
+                    .orElse("");
 
             String experimentDescription = getParsedOutputByKey(EXPERIMENT_DESCRIPTION_ID, emptyList())
                     .stream()

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserTest.java
@@ -134,28 +134,6 @@ class IdfParserTest {
     }
 
     @Test
-    void parseForTABMAccession() {
-        dataFileHub.addIdfFile("E-TABM-0001", Arrays.asList(IDF_TXT));
-
-        IdfParserOutput idfParserOutput = subject.parse("E-TABM-0001");
-
-        assertThat(idfParserOutput.getTitle()).isEqualTo(AE_DISPLAY_NAME);
-        assertThat(idfParserOutput.getPubmedIds()).containsOnlyElementsOf(PUBMED_IDS);
-        assertThat(idfParserOutput.getExpectedClusters()).isEqualTo(NumberUtils.toInt(EXPECTED_CLUSTERS));
-    }
-
-    @Test
-    void parseForNonMTABAccession() {
-        dataFileHub.addIdfFile("E-GEOD-0001", Arrays.asList(IDF_TXT));
-
-        IdfParserOutput idfParserOutput = subject.parse("E-GEOD-0001");
-
-        assertThat(idfParserOutput.getTitle()).isEqualTo(TITLE);
-        assertThat(idfParserOutput.getPubmedIds()).containsOnlyElementsOf(PUBMED_IDS);
-        assertThat(idfParserOutput.getExpectedClusters()).isEqualTo(NumberUtils.toInt(EXPECTED_CLUSTERS));
-    }
-
-    @Test
     void parseNothing() {
         dataFileHub.addIdfFile(E_MTAB_513, Collections.emptyList());
 


### PR DESCRIPTION
- Reverted to the old way of retrieving the experiment title from the idf, i.e. retrive the Array Express display name if present, if not retrieve the investigation title