### PR TITLE
Bugfix #160821167 - IdfParser doesn't handle whitespaces in comment fields

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParser.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParser.java
@@ -1,7 +1,8 @@
 package uk.ac.ebi.atlas.experimentimport.idf;
 
+import com.google.common.base.Strings;
 import org.apache.commons.lang.math.NumberUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.StringUtils;
 import uk.ac.ebi.atlas.commons.readers.TsvStreamer;
 import uk.ac.ebi.atlas.model.Publication;
 import uk.ac.ebi.atlas.resource.DataFileHub;
@@ -32,7 +33,7 @@ public class IdfParser {
     private static final Set<String> LINE_IDS = Stream.of(INVESTIGATION_TITLE_ID, EXPERIMENT_DESCRIPTION_ID, PUBMED_ID,
             PUBLICATION_TITLE_ID, PUBLICATION_DOI_ID, AE_EXPERIMENT_DISPLAY_NAME_ID, EXPECTED_CLUSTERS_ID,
             ADDITIONAL_ATTRIBUTES_ID)
-                .map(String::toUpperCase)
+                .map(IdfParser::convertIdfFieldNameToKey)
                 .collect(Collectors.toSet());
 
     private DataFileHub dataFileHub;
@@ -46,12 +47,11 @@ public class IdfParser {
 
     public IdfParserOutput parse(String experimentAccession) {
         try (TsvStreamer idfStreamer = dataFileHub.getExperimentFiles(experimentAccession).idf.get()) {
-
             parsedIdf = idfStreamer.get()
                             .filter(line -> line.length > 1)
-                            .filter(line -> LINE_IDS.contains(line[0].trim().toUpperCase()))
+                            .filter(line -> LINE_IDS.contains(convertIdfFieldNameToKey(line[0])))
                             .collect(Collectors.toMap(
-                                    line -> line[0].trim().toUpperCase(),
+                                    line -> convertIdfFieldNameToKey(line[0]),
                                     line -> Arrays.stream(line)
                                             .skip(1)
                                             .filter(item -> !item.isEmpty())
@@ -114,9 +114,9 @@ public class IdfParser {
     }
 
     private List<String> getParsedOutputByKey(String key, List<String> outputIfEmpty) {
-        List<String> values = parsedIdf.getOrDefault(key.toUpperCase(), emptyList());
+        List<String> values = parsedIdf.getOrDefault(convertIdfFieldNameToKey(key), emptyList());
 
-        if (values.isEmpty() || values.stream().allMatch(StringUtils::isBlank)) {
+        if (values.isEmpty() || values.stream().allMatch(org.apache.commons.lang.StringUtils::isBlank)) {
             return outputIfEmpty;
         }
 
@@ -125,5 +125,9 @@ public class IdfParser {
 
     private String getPublicationInformation(int index, List<String> list) {
         return index < list.size() ? list.get(index) : null;
+    }
+
+    private static String convertIdfFieldNameToKey(String idfField) {
+        return StringUtils.trimAllWhitespace(idfField).toUpperCase();
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserTest.java
@@ -15,7 +15,7 @@ class IdfParserTest {
 
     private static final String E_MTAB_513 = "E-MTAB-513";
 
-    private static final String TITLE =
+    private static final String INVESTIGATION_TITLE =
             "RNA-Seq of human individual tissues and mixture of 16 tissues (Illumina Body Map)";
     private static final String AE_DISPLAY_NAME =
             "Study investigating RNA-Seq of human individual tissues and mixture of 16 tissues";
@@ -31,7 +31,7 @@ class IdfParserTest {
             {"individual", "genotype", "FACS marker"};
 
     private static final String[][] IDF_TXT = {
-            {"Investigation Title", TITLE},
+            {"Investigation Title", INVESTIGATION_TITLE},
             {"Comment[AEExperimentDisplayName]", AE_DISPLAY_NAME},
             {"PubMed ID", PUBMED_IDS_ARRAY[0], PUBMED_IDS_ARRAY[1], PUBMED_IDS_ARRAY[2]},
             {"Publication Title", PUBLICATIONS_ARRAY[0], PUBLICATIONS_ARRAY[1], PUBLICATIONS_ARRAY[2]},
@@ -42,8 +42,19 @@ class IdfParserTest {
             }
     };
 
+    private static final String[][] IDF_TXT_WHITESPACES_IN_COMMENTS = {
+            {"Investigation Title", INVESTIGATION_TITLE},
+            {"Comment [AEExperimentDisplayName]", AE_DISPLAY_NAME},
+            {"Comment [EAExpectedClusters]", EXPECTED_CLUSTERS},
+    };
+
+    private static final String[][] IDF_TXT_SPACES_IN_FIELD_VALUES = {
+            {"Investigation Title", INVESTIGATION_TITLE},
+            {"Comment [AEExperimentDisplayName]", "     "},
+    };
+
     private static final String[][] IDF_TXT_MIXED_CASE = {
-            {"INVESTIGATION TITLE   ", TITLE},
+            {"INVESTIGATION INVESTIGATION_TITLE   ", INVESTIGATION_TITLE},
             {" comment[AEExperimentDisplayName]", AE_DISPLAY_NAME},
             {"PubMed id", PUBMED_IDS_ARRAY[0], PUBMED_IDS_ARRAY[1], PUBMED_IDS_ARRAY[2]},
             {"publication title", PUBLICATIONS_ARRAY[0], PUBLICATIONS_ARRAY[1], PUBLICATIONS_ARRAY[2]},
@@ -51,20 +62,20 @@ class IdfParserTest {
     };
 
     private static final String[][] IDF_TXT_DUPLICATE_FIELDS = {
-            {"Investigation Title", TITLE},
+            {"Investigation Title", INVESTIGATION_TITLE},
             {"Comment[AEExperimentDisplayName]", AE_DISPLAY_NAME},
             {"Comment[AEExperimentDisplayName]", "Foobar"},
             {"PubMed ID", PUBMED_IDS_ARRAY[0], PUBMED_IDS_ARRAY[1], PUBMED_IDS_ARRAY[2]},
             {"Publication Title", PUBLICATIONS_ARRAY[0], PUBLICATIONS_ARRAY[1], PUBLICATIONS_ARRAY[2]},
             {"Comment[EAExpectedClusters]", EXPECTED_CLUSTERS},
             {
-                    "Comment[EAAdditionalAttributes]",
-                    ADDITIONAL_ATTRIBUTES[0], ADDITIONAL_ATTRIBUTES[1], ADDITIONAL_ATTRIBUTES[2]
+                "Comment[EAAdditionalAttributes]",
+                ADDITIONAL_ATTRIBUTES[0], ADDITIONAL_ATTRIBUTES[1], ADDITIONAL_ATTRIBUTES[2]
             }
     };
 
     private static final String[][] IDF_TXT_EMPTY_DISPLAY_NAME = {
-            {"Investigation Title", TITLE},
+            {"Investigation Title", INVESTIGATION_TITLE},
             {"Comment[AEExperimentDisplayName]", ""}
     };
 
@@ -119,7 +130,7 @@ class IdfParserTest {
 
         IdfParserOutput idfParserOutput = subject.parse(E_MTAB_513);
 
-        assertThat(idfParserOutput.getTitle()).isEqualTo(TITLE);
+        assertThat(idfParserOutput.getTitle()).isEqualTo(INVESTIGATION_TITLE);
         assertThat(idfParserOutput.getPubmedIds()).containsOnlyElementsOf(PUBMED_IDS);
     }
 
@@ -159,6 +170,25 @@ class IdfParserTest {
 
         IdfParserOutput idfParserOutput = subject.parse(E_MTAB_513);
 
-        assertThat(idfParserOutput.getTitle()).isEqualTo(TITLE);
+        assertThat(idfParserOutput.getTitle()).isEqualTo(INVESTIGATION_TITLE);
+    }
+
+    @Test
+    void parsesCommentsWithWhitespaces() {
+        dataFileHub.addIdfFile(E_MTAB_513, Arrays.asList(IDF_TXT_WHITESPACES_IN_COMMENTS));
+
+        IdfParserOutput idfParserOutput = subject.parse(E_MTAB_513);
+
+        assertThat(idfParserOutput.getTitle()).isEqualTo(AE_DISPLAY_NAME);
+        assertThat(idfParserOutput.getExpectedClusters()).isEqualTo(NumberUtils.toInt(EXPECTED_CLUSTERS));
+    }
+
+    @Test
+    void ignoresFieldsWithEmptyValuesMadeUpOfWhitespaces() {
+        dataFileHub.addIdfFile(E_MTAB_513, Arrays.asList(IDF_TXT_SPACES_IN_FIELD_VALUES));
+
+        IdfParserOutput idfParserOutput = subject.parse(E_MTAB_513);
+
+        assertThat(idfParserOutput.getTitle()).isEqualTo(INVESTIGATION_TITLE);
     }
 }


### PR DESCRIPTION
- Added handling for `Comment [field_name]`
- Added additional test cases