### PR TITLE
Feature #160591849 - Add additional attributes to tooltip

### DIFF
--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
@@ -13,6 +13,7 @@ import uk.ac.ebi.atlas.resource.DataFileHub;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
@@ -46,9 +47,11 @@ public class ExperimentPageContentService {
         result.add("perplexities", perplexityArray);
 
         JsonArray metadataArray = new JsonArray();
-        cellMetadataDao.getMetadataFieldNames(experimentAccession)
-                .stream()
+        Stream.concat(
+                cellMetadataDao.getMetadataFieldNames(experimentAccession).stream(),
+                cellMetadataDao.getAdditionalAttributesFieldNames(experimentAccession).stream())
                 .map(x -> ImmutableMap.of("value", x.name(), "label", x.displayName()))
+                .collect(Collectors.toSet())
                 .forEach(x -> metadataArray.add(GSON.toJsonTree(x)));
 
         result.add("metadata", metadataArray);

--- a/sc/src/main/java/uk/ac/ebi/atlas/metadata/CellMetadataService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/metadata/CellMetadataService.java
@@ -1,29 +1,23 @@
 package uk.ac.ebi.atlas.metadata;
 
 import org.springframework.stereotype.Component;
-import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
-import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.SingleCellAnalyticsSchemaField;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
-import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.attributeNameToFieldName;
-import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.characteristicAsSchemaField;
 
 @Component
 public class CellMetadataService {
-    private IdfParser idfParser;
     private CellMetadataDao cellMetadataDao;
 
-    public CellMetadataService(IdfParser idfParser, CellMetadataDao cellMetadataDao) {
-        this.idfParser = idfParser;
+    public CellMetadataService(CellMetadataDao cellMetadataDao) {
         this.cellMetadataDao = cellMetadataDao;
     }
 
@@ -46,35 +40,16 @@ public class CellMetadataService {
     }
 
     public Map<String, String> getMetadata(String experimentAccession, String cellId) {
-        List<SingleCellAnalyticsSchemaField> metadataFieldNames =
-                cellMetadataDao.getMetadataFieldNames(experimentAccession);
+        Set<SingleCellAnalyticsSchemaField> metadataFieldNames = Stream.concat(
+                cellMetadataDao.getMetadataFieldNames(experimentAccession).stream(),
+                cellMetadataDao.getAdditionalAttributesFieldNames(experimentAccession).stream())
+                .collect(Collectors.toSet());
 
         return cellMetadataDao
                 .getQueryResultForMultiValueFields(experimentAccession, Optional.of(cellId), metadataFieldNames)
                 .entrySet().stream()
                 .collect(toMap(
                         entry -> SingleCellAnalyticsCollectionProxy.metadataFieldNameToDisplayName(entry.getKey()),
-                        entry -> entry.getValue().stream().map(Object::toString).collect(Collectors.joining(","))));
-    }
-
-    // This is not currently used but leaving in for now in case the logic is still useful
-    protected Map<String, String> getIdfFileAttributes(String experimentAccession, String cellId) {
-        IdfParserOutput idfParserOutput = idfParser.parse(experimentAccession);
-
-        if (idfParserOutput.getMetadataFieldsOfInterest().isEmpty()) {
-            return emptyMap();
-        }
-
-        List<SingleCellAnalyticsSchemaField> attributeFields = idfParserOutput.getMetadataFieldsOfInterest()
-                .stream()
-                .map(attribute -> characteristicAsSchemaField(attributeNameToFieldName(attribute)))
-                .collect(toList());
-
-        return cellMetadataDao
-                .getQueryResultForMultiValueFields(experimentAccession, Optional.of(cellId), attributeFields)
-                .entrySet().stream()
-                .collect(toMap(
-                        Map.Entry::getKey,
                         entry -> entry.getValue().stream().map(Object::toString).collect(Collectors.joining(","))));
     }
 }

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentServiceIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentServiceIT.java
@@ -136,6 +136,13 @@ class ExperimentPageContentServiceIT {
         assertThat(result.has("perplexities")).isTrue();
         assertThat(result.get("perplexities").getAsJsonArray()).isNotEmpty();
 
+        // Not all experiments have metadata, see E-GEOD-99058
+        if (result.has("metadata")) {
+            assertThat(result.get("metadata").getAsJsonArray())
+                    .isNotEmpty()
+                    .doesNotHaveDuplicates();
+        }
+
         assertThat(result.has("units")).isTrue();
         assertThat(result.get("units").getAsJsonArray()).isNotEmpty();
     }

--- a/sc/src/test/java/uk/ac/ebi/atlas/metadata/CellMetadataServiceIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/metadata/CellMetadataServiceIT.java
@@ -10,11 +10,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.WebConfig;
-import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.testutils.JdbcUtils;
 
 import javax.inject.Inject;
-
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,8 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ContextConfiguration(classes = WebConfig.class)
 class CellMetadataServiceIT {
     @Inject
-    private IdfParser idfParser;
-    @Inject
     private CellMetadataDao cellMetadataDao;
     @Inject
     private JdbcUtils jdbcUtils;
@@ -35,7 +31,7 @@ class CellMetadataServiceIT {
 
     @BeforeEach
     void setUp() {
-        this.subject = new CellMetadataService(idfParser, cellMetadataDao);
+        this.subject = new CellMetadataService(cellMetadataDao);
     }
 
     @Test
@@ -84,35 +80,6 @@ class CellMetadataServiceIT {
     @Test
     void metadataForInvalidExperiment() {
         assertThat(subject.getMetadata("FOO", "FOO")).isEmpty();
-    }
-
-    @Test
-    void experimentWithMetadataFieldsInIdf() {
-        // Ideally we would retrieve a random experiment accession, but not all experiments have curated metadata
-        // files in the IDF file
-        assertThat(
-                subject.getIdfFileAttributes(
-                        "E-ENAD-14",
-                        jdbcUtils.fetchRandomCellFromExperiment("E-ENAD-14")))
-                .isNotEmpty()
-                .containsOnlyKeys("characteristic_individual");
-    }
-
-    @Test
-    void experimentWithoutMetadataFieldsInIdf() {
-        String experimentAccession = "E-GEOD-99058";    // Empty Comment[EAAdditionalAttributes] in IDF file
-
-        assertThat(
-                subject.getIdfFileAttributes(
-                        experimentAccession,
-                        jdbcUtils.fetchRandomCellFromExperiment(experimentAccession)))
-                .isEmpty();
-
-        assertThat(
-                subject.getFactors(
-                        experimentAccession,
-                        jdbcUtils.fetchRandomCellFromExperiment(experimentAccession)))
-                .isEmpty();
     }
 
     private Iterable<String> experimentsWithMetadataProvider() {


### PR DESCRIPTION
Note: I branched from https://github.com/ebi-gene-expression-group/atlas/tree/feature/160591968-add-additional-attributes-to-dropdown so you can ignore the first commit. There is an [additional PR](https://github.com/ebi-gene-expression-group/atlas/pull/174) for that.

- Added additional attributes to the metadata retrived through the cell metadata endpoint
- Cleaned up code