### PR TITLE
Bugfix #161676946 – SC gene search endpoint is picky about reuest parameters order

### DIFF
--- a/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -60,18 +60,19 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
     public String search(@RequestParam MultiValueMap<String, String> requestParams) {
         Optional<Species> species = Optional.ofNullable(requestParams.getFirst("species")).map(speciesFactory::create);
 
-        Stream<String> validQueryFields =
-                Stream.concat(Stream.of("q"), ID_PROPERTY_NAMES.stream().map(BioentityPropertyName::name));
+        List<String> validQueryFields =
+                ImmutableList.<String>builder()
+                        .add("q")
+                        .addAll(ID_PROPERTY_NAMES.stream().map(propertyName -> propertyName.name).collect(toList()))
+                        .build();
 
         // We support currently only one query term; in the unlikely case that somebody fabricates a URL with more than
         // one we’ll build the query with the first match. Remember that in order to support multiple terms we’ll
         // likely need to change GeneQuery and use internally a SemanticQuery
         String category =
                 requestParams.keySet().stream()
-                        .filter(
-                                actualField ->
-                                        validQueryFields.anyMatch(
-                                                validField -> validField.equalsIgnoreCase(actualField)))
+                        // We rely on "q" and BioentityPropertyName::name’s being lower case
+                        .filter(actualField -> validQueryFields.contains(actualField.toLowerCase()))
                         .findFirst()
                         .orElseThrow(() -> new RuntimeException("Error parsing query"));
 

--- a/sc/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.search;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,10 @@ import uk.ac.ebi.atlas.testutils.JdbcUtils;
 import javax.inject.Inject;
 import javax.sql.DataSource;
 
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.shuffle;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -103,5 +108,11 @@ class JsonGeneSearchControllerWIT {
                 .andExpect(jsonPath("$.results[0].facets[0].value", isA(String.class)))
                 .andExpect(jsonPath("$.results[0].facets[0].label", isA(String.class)))
                 .andExpect(jsonPath("$.checkboxFacetGroups", contains("Marker genes", "Species")));
+    }
+
+    @Test
+    void speciesParamCanAppearBeforeGeneQuery() throws Exception {
+        this.mockMvc.perform(get("/json/search").param("species", "homo sapiens").param("symbol", "aspm"))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
I caught this one while testing the gene search SPA, and because `query-string` sorts parameters alphabetically (so that I ended up with `species` before `symbol`). An obscure bug!