### PR TITLE
Feature #161765872 – Bring back controller for `/api/contrastdetails.tsv` and `/api/assaygroupsdetails.tsv`

### DIFF
--- a/gxa/src/main/java/uk/ac/ebi/atlas/ebeyedump/BaselineExperimentAssayGroupsLines.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/ebeyedump/BaselineExperimentAssayGroupsLines.java
@@ -1,0 +1,67 @@
+package uk.ac.ebi.atlas.ebeyedump;
+
+import com.google.common.collect.ImmutableList;
+import uk.ac.ebi.atlas.model.AssayGroup;
+import uk.ac.ebi.atlas.model.OntologyTerm;
+import uk.ac.ebi.atlas.model.SampleCharacteristic;
+import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
+import uk.ac.ebi.atlas.model.experiment.baseline.Factor;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static java.util.stream.Collectors.joining;
+
+public class BaselineExperimentAssayGroupsLines implements Iterable<String[]> {
+    private final LinkedHashSet<ImmutableList<String>> result = new LinkedHashSet<>();
+    private final LinkedHashSet<ImmutableList<String>> assayGroupsDetails;
+
+    public BaselineExperimentAssayGroupsLines(BaselineExperiment experiment) {
+        assayGroupsDetails = buildAssayGroupsDetails(experiment);
+    }
+
+    private LinkedHashSet<ImmutableList<String>> buildAssayGroupsDetails(BaselineExperiment experiment) {
+        for (AssayGroup assayGroupById : experiment.getDataColumnDescriptors()) {
+            for (String assayAccession : assayGroupById.assaysAnalyzedForThisDataColumn()) {
+                this.populateSamples(experiment, assayAccession, assayGroupById);
+                this.populateFactors(experiment, assayAccession, assayGroupById);
+            }
+        }
+
+        return result;
+    }
+
+    private void populateSamples(BaselineExperiment experiment, String assayAccession, AssayGroup assayGroup) {
+        for (SampleCharacteristic sample : experiment.getExperimentDesign().getSampleCharacteristics(assayAccession)) {
+            ImmutableList<String> line =
+                    ImmutableList.of(
+                            experiment.getAccession(),
+                            assayGroup.getId(),
+                            "characteristic",
+                            sample.header(),
+                            sample.value(),
+                            joinURIs(sample.valueOntologyTerms()));
+            result.add(line);
+        }
+    }
+
+    private void populateFactors(BaselineExperiment experiment, String assayAccession, AssayGroup assayGroup) {
+        for (Factor factor : experiment.getExperimentDesign().getFactors(assayAccession)) {
+            ImmutableList<String> line = ImmutableList.of(experiment.getAccession(), assayGroup.getId(), "factor",
+                    factor.getHeader(), factor.getValue(), joinURIs(factor.getValueOntologyTerms()));
+            result.add(line);
+        }
+    }
+
+    private static String joinURIs(Set<OntologyTerm> ontologyTerms) {
+        return ontologyTerms.stream().map(OntologyTerm::uri).collect(joining(" "));
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<String[]> iterator() {
+        return assayGroupsDetails.stream().map(list -> list.toArray(new String[0])).iterator();
+    }
+}

--- a/gxa/src/main/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLines.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLines.java
@@ -1,0 +1,86 @@
+package uk.ac.ebi.atlas.ebeyedump;
+
+import com.google.common.collect.ImmutableList;
+import uk.ac.ebi.atlas.model.OntologyTerm;
+import uk.ac.ebi.atlas.model.SampleCharacteristic;
+import uk.ac.ebi.atlas.model.experiment.baseline.Factor;
+import uk.ac.ebi.atlas.model.experiment.differential.Contrast;
+import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static java.util.stream.Collectors.joining;
+
+public class DifferentialExperimentContrastLines implements Iterable<String[]> {
+    private final LinkedHashSet<ImmutableList<String>> contrastDetails;
+    private final LinkedHashSet<ImmutableList<String>> result = new LinkedHashSet<>();
+
+    public DifferentialExperimentContrastLines(DifferentialExperiment experiment) {
+        this.contrastDetails = buildContrastDetails(experiment);
+    }
+
+    private LinkedHashSet<ImmutableList<String>> buildContrastDetails(DifferentialExperiment experiment) {
+        for (Contrast contrast : experiment.getDataColumnDescriptors()) {
+            for (String assayAccession : contrast.getReferenceAssayGroup().assaysAnalyzedForThisDataColumn()) {
+                this.populateSamples(experiment, assayAccession, contrast, "reference");
+                this.populateFactors(experiment, assayAccession, contrast, "reference");
+            }
+
+            for (String assayAccession : contrast.getTestAssayGroup().assaysAnalyzedForThisDataColumn()) {
+                this.populateSamples(experiment, assayAccession, contrast, "test");
+                this.populateFactors(experiment, assayAccession, contrast, "test");
+            }
+        }
+
+        return result;
+    }
+
+    private void populateSamples(DifferentialExperiment experiment,
+                                 String assayAccession,
+                                 Contrast contrast,
+                                 String value) {
+        for (SampleCharacteristic sample : experiment.getExperimentDesign().getSampleCharacteristics(assayAccession)) {
+            ImmutableList<String> line =
+                    ImmutableList.of(
+                            experiment.getAccession(),
+                            contrast.getId(),
+                            value,
+                            "characteristic",
+                            sample.header(),
+                            sample.value(),
+                            joinURIs(sample.valueOntologyTerms()));
+            result.add(line);
+        }
+    }
+
+    private void populateFactors(DifferentialExperiment experiment,
+                                 String assayAccession,
+                                 Contrast contrast, String value) {
+        for (Factor factor : experiment.getExperimentDesign().getFactors(assayAccession)) {
+            ImmutableList<String> line =
+                    ImmutableList.of(
+                            experiment.getAccession(),
+                            contrast.getId(),
+                            value,
+                            "factor",
+                            factor.getHeader(),
+                            factor.getValue(),
+                            joinURIs(factor.getValueOntologyTerms()));
+            result.add(line);
+        }
+
+    }
+
+    private static String joinURIs(Set<OntologyTerm> ontologyTerms) {
+        return ontologyTerms.stream().map(OntologyTerm::uri).collect(joining(" "));
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<String[]> iterator() {
+        return contrastDetails.stream().map(list -> list.toArray(new String[0])).iterator();
+    }
+}

--- a/gxa/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
@@ -1,0 +1,69 @@
+package uk.ac.ebi.atlas.ebeyedump;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import uk.ac.ebi.atlas.model.experiment.Experiment;
+import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
+import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
+import uk.ac.ebi.atlas.trader.ExpressionAtlasExperimentTrader;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Function;
+
+import static java.lang.String.join;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_BASELINE;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_DIFFERENTIAL;
+
+@Controller
+@Scope("request")
+public class ExperimentsConditionsDetailsController {
+    private ExpressionAtlasExperimentTrader experimentTrader;
+
+    public ExperimentsConditionsDetailsController(ExpressionAtlasExperimentTrader experimentTrader) {
+        this.experimentTrader = experimentTrader;
+    }
+
+    @GetMapping("/api/assaygroupsdetails.tsv")
+    public void generateTsvFormatBaseline(HttpServletResponse response) {
+        writeTsvLinesToResponse(
+                response,
+                experiment -> new BaselineExperimentAssayGroupsLines((BaselineExperiment) experiment),
+                RNASEQ_MRNA_BASELINE,
+                PROTEOMICS_BASELINE);
+    }
+
+    @GetMapping("/api/contrastdetails.tsv")
+    public void generateTsvFormatDifferential(HttpServletResponse response) {
+        writeTsvLinesToResponse(
+                response,
+                experiment -> new DifferentialExperimentContrastLines((DifferentialExperiment) experiment),
+                MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL,
+                MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL,
+                MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL,
+                RNASEQ_MRNA_DIFFERENTIAL);
+    }
+
+    private void writeTsvLinesToResponse(HttpServletResponse response,
+                                         Function<Experiment, Iterable<String[]>> linesIteratorProducer,
+                                         ExperimentType... experimentTypes) {
+        response.setContentType("text/tab-separated-values");
+
+        try {
+            for (Experiment experiment : experimentTrader.getPublicExperiments(experimentTypes)) {
+                for (String[] line : linesIteratorProducer.apply(experiment)) {
+                    response.getWriter().write(join("\t", line) + "\n");
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/gxa/src/test/java/uk/ac/ebi/atlas/ebeyedump/BaselineExperimentAssayGroupsLinesTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/ebeyedump/BaselineExperimentAssayGroupsLinesTest.java
@@ -1,0 +1,143 @@
+package uk.ac.ebi.atlas.ebeyedump;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ebi.atlas.model.AssayGroup;
+import uk.ac.ebi.atlas.model.BiologicalReplicate;
+import uk.ac.ebi.atlas.model.OntologyTerm;
+import uk.ac.ebi.atlas.model.SampleCharacteristic;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
+import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
+
+import javax.naming.OperationNotSupportedException;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.joining;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.wrap;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaselineExperimentAssayGroupsLinesTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaselineExperimentAssayGroupsLinesTest.class);
+
+    private static final String EXPERIMENT_ACCESSION = "EXPERIMENT_ACCESSION";
+    private static final String ASSAY1 = "ASSAY1";
+    private static final String ASSAY2 = "ASSAY2";
+    private static final String ASSAY3 = "ASSAY3";
+    private static final String SAMPLE_HEADER = "SAMPLE_HEADER1";
+    private static final String FACTOR_HEADER = "FACTOR_HEADER1";
+
+    private static final String FACTOR_VALUE1 = "FACTOR_VALUE1";
+    private static final String FACTOR_VALUE2 = "FACTOR_VALUE2";
+    private static final String FACTOR_VALUE3 = "FACTOR_VALUE3";
+
+    private static final String SAMPLE_VALUE1 = "SAMPLE_VALUE1";
+    private static final String SAMPLE_VALUE2 = "SAMPLE_VALUE2";
+    private static final String SAMPLE_VALUE3 = "SAMPLE_VALUE3";
+    private static final String CHARACTERISTIC = "characteristic";
+    private static final String FACTOR = "factor";
+
+    private static final String HTTP_OBO = "http://purl.obolibrary.org/obo/";
+    private static final String FACTOR_ONTOLOGY_ID1 = "F:1";
+    private static final OntologyTerm FACTOR_ONTOLOGY_TERM1 = OntologyTerm.create(FACTOR_ONTOLOGY_ID1, "", HTTP_OBO);
+    private static final String FACTOR_ONTOLOGY_ID2 = "F:2";
+    private static final OntologyTerm FACTOR_ONTOLOGY_TERM2 = OntologyTerm.create(FACTOR_ONTOLOGY_ID2, "", "");
+
+    private static final String SAMPLE_ONTOLOGY_ID1 = "S:1";
+    private static final OntologyTerm SAMPLE_ONTOLOGY_TERM1 = OntologyTerm.create(SAMPLE_ONTOLOGY_ID1, "", HTTP_OBO);
+    private static final String SAMPLE_ONTOLOGY_ID2 = "S:2";
+    private static final OntologyTerm SAMPLE_ONTOLOGY_TERM2 = OntologyTerm.create(SAMPLE_ONTOLOGY_ID2, "", "");
+
+    private static final String G1 = "g1";
+    private static final AssayGroup ASSAY_GROUP1 =
+            new AssayGroup(G1, ImmutableSet.of(new BiologicalReplicate(ASSAY1)));
+    private static final String G2 = "g2";
+    private static final AssayGroup ASSAY_GROUP2 =
+            new AssayGroup(G2, ImmutableSet.of(new BiologicalReplicate(ASSAY2)));
+    private static final String G3 = "g3";
+    private static final AssayGroup ASSAY_GROUP3 =
+            new AssayGroup(G3, ImmutableSet.of(new BiologicalReplicate(ASSAY3)));
+
+    @Mock
+    private BaselineExperiment baselineExperiment;
+
+    @Test
+    public void lines() {
+        ExperimentDesign experimentDesign = new ExperimentDesign();
+
+        SampleCharacteristic sampleCharacteristic1 =
+                SampleCharacteristic.create(SAMPLE_HEADER, SAMPLE_VALUE1, SAMPLE_ONTOLOGY_TERM1);
+        SampleCharacteristic sampleCharacteristic2 =
+                SampleCharacteristic.create(SAMPLE_HEADER, SAMPLE_VALUE2, SAMPLE_ONTOLOGY_TERM2);
+
+
+        experimentDesign.putSampleCharacteristic(ASSAY1, SAMPLE_HEADER, sampleCharacteristic1);
+        experimentDesign.putFactor(ASSAY1, FACTOR_HEADER, FACTOR_VALUE1, FACTOR_ONTOLOGY_TERM1);
+
+        experimentDesign.putSampleCharacteristic(ASSAY2, SAMPLE_HEADER, sampleCharacteristic2);
+        experimentDesign.putFactor(ASSAY2, FACTOR_HEADER, FACTOR_VALUE2, FACTOR_ONTOLOGY_TERM2);
+
+        experimentDesign.putSampleCharacteristic(ASSAY3, SAMPLE_HEADER, SAMPLE_VALUE3);
+        experimentDesign.putFactor(ASSAY3, FACTOR_HEADER, FACTOR_VALUE3);
+
+
+        when(baselineExperiment.getAccession()).thenReturn(EXPERIMENT_ACCESSION);
+        when(baselineExperiment.getDataColumnDescriptors()).thenReturn(ImmutableList.of(ASSAY_GROUP1, ASSAY_GROUP2,
+                ASSAY_GROUP3));
+        when(baselineExperiment.getExperimentDesign()).thenReturn(experimentDesign);
+
+        BaselineExperimentAssayGroupsLines subject = new BaselineExperimentAssayGroupsLines(baselineExperiment);
+
+        Iterator<String[]> lines = subject.iterator();
+
+        subject.forEach(line ->
+                LOGGER.info(
+                        Arrays.stream(line)
+                                .map(field -> wrap(field, "\""))
+                                .map(field -> isBlank(field) ? "\"\"" : field)
+                                .collect(joining(","))));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, G1, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE1,
+                        HTTP_OBO + SAMPLE_ONTOLOGY_ID1}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, G1, FACTOR, FACTOR_HEADER, FACTOR_VALUE1,
+                        HTTP_OBO + FACTOR_ONTOLOGY_ID1}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, G2, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE2, SAMPLE_ONTOLOGY_ID2}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, G2, FACTOR, FACTOR_HEADER, FACTOR_VALUE2, FACTOR_ONTOLOGY_ID2}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, G3, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE3, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, G3, FACTOR, FACTOR_HEADER, FACTOR_VALUE3, ""}));
+    }
+}

--- a/gxa/src/test/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLinesTest.java
+++ b/gxa/src/test/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLinesTest.java
@@ -1,0 +1,298 @@
+package uk.ac.ebi.atlas.ebeyedump;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.internal.Diff;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.ac.ebi.atlas.model.AssayGroup;
+import uk.ac.ebi.atlas.model.BiologicalReplicate;
+import uk.ac.ebi.atlas.model.OntologyTerm;
+import uk.ac.ebi.atlas.model.SampleCharacteristic;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
+import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
+import uk.ac.ebi.atlas.model.experiment.differential.Contrast;
+import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
+import uk.ac.ebi.atlas.species.Species;
+import uk.ac.ebi.atlas.species.SpeciesProperties;
+
+import javax.naming.OperationNotSupportedException;
+import java.util.Date;
+import java.util.Iterator;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DifferentialExperimentContrastLinesTest {
+    private static final String EXPERIMENT_ACCESSION = "EXPERIMENT_ACCESSION";
+    private static final String CONTRAST_ID = "CONTRAST_ID";
+    private static final String ASSAY1 = "ASSAY1";
+    private static final String ASSAY2 = "ASSAY2";
+    private static final String ASSAY3 = "ASSAY3";
+    private static final String ASSAY4 = "ASSAY4";
+    private static final String SAMPLE_HEADER = "SAMPLE_HEADER1";
+    private static final String FACTOR_HEADER = "FACTOR_HEADER1";
+
+    private static final String FACTOR_VALUE1 = "FACTOR_VALUE1";
+    private static final String FACTOR_VALUE2 = "FACTOR_VALUE2";
+
+    private static final String SAMPLE_VALUE1 = "SAMPLE_VALUE1";
+    private static final String SAMPLE_VALUE2 = "SAMPLE_VALUE2";
+    private static final String SAMPLE_VALUE3 = "SAMPLE_VALUE3";
+    private static final String SAMPLE_VALUE4 = "SAMPLE_VALUE4";
+    private static final String REFERENCE = "reference";
+    private static final String CHARACTERISTIC = "characteristic";
+    private static final String FACTOR = "factor";
+    private static final String TEST = "test";
+
+    private static final String HTTP_OBO = "http://purl.obolibrary.org/obo/";
+    private static final String FACTOR_ONTOLOGY_ID1 = "F:1";
+    private static final OntologyTerm FACTOR_ONTOLOGY_TERM1 = OntologyTerm.create(FACTOR_ONTOLOGY_ID1, "", HTTP_OBO);
+    private static final String FACTOR_ONTOLOGY_ID2 = "F:2";
+    private static final OntologyTerm FACTOR_ONTOLOGY_TERM2 = OntologyTerm.create(FACTOR_ONTOLOGY_ID2, "", "");
+
+    private static final String SAMPLE_ONTOLOGY_ID1 = "S:1";
+    private static final OntologyTerm SAMPLE_ONTOLOGY_TERM1 = OntologyTerm.create(SAMPLE_ONTOLOGY_ID1, "", HTTP_OBO);
+    private static final String SAMPLE_ONTOLOGY_ID2 = "S:2";
+    private static final OntologyTerm SAMPLE_ONTOLOGY_TERM2 = OntologyTerm.create(SAMPLE_ONTOLOGY_ID2, "", "");
+
+    @Mock
+    private DifferentialExperiment differentialExperimentMock;
+
+    private DifferentialExperimentContrastLines subject;
+
+    @Test
+    public void contrastDetailLines() {
+        AssayGroup referenceAssayGroup =
+                new AssayGroup(
+                        "g1",
+                        ImmutableSet.of(new BiologicalReplicate(ASSAY1), new BiologicalReplicate(ASSAY2)));
+        AssayGroup testAssayGroup =
+                new AssayGroup(
+                        "g2",
+                        ImmutableSet.of(new BiologicalReplicate(ASSAY3), new BiologicalReplicate(ASSAY4)));
+        Contrast contrast1 =
+                new Contrast(
+                        CONTRAST_ID, "array design accession", referenceAssayGroup, testAssayGroup, "display name");
+
+        ExperimentDesign experimentDesign = new ExperimentDesign();
+
+        SampleCharacteristic sampleCharacteristic1 =
+                SampleCharacteristic.create(SAMPLE_HEADER, SAMPLE_VALUE1, SAMPLE_ONTOLOGY_TERM1);
+        SampleCharacteristic sampleCharacteristic2 =
+                SampleCharacteristic.create(SAMPLE_HEADER, SAMPLE_VALUE2, SAMPLE_ONTOLOGY_TERM2);
+
+
+        experimentDesign.putSampleCharacteristic(ASSAY1, SAMPLE_HEADER, sampleCharacteristic1);
+        experimentDesign.putFactor(ASSAY1, FACTOR_HEADER, FACTOR_VALUE1, FACTOR_ONTOLOGY_TERM1);
+        experimentDesign.putSampleCharacteristic(ASSAY2, SAMPLE_HEADER, sampleCharacteristic2);
+        experimentDesign.putFactor(ASSAY2, FACTOR_HEADER, FACTOR_VALUE1, FACTOR_ONTOLOGY_TERM1);
+
+        experimentDesign.putSampleCharacteristic(ASSAY3, SAMPLE_HEADER, SAMPLE_VALUE3);
+        experimentDesign.putFactor(ASSAY3, FACTOR_HEADER, FACTOR_VALUE2, FACTOR_ONTOLOGY_TERM2);
+        experimentDesign.putSampleCharacteristic(ASSAY4, SAMPLE_HEADER, SAMPLE_VALUE4);
+        experimentDesign.putFactor(ASSAY4, FACTOR_HEADER, FACTOR_VALUE2, FACTOR_ONTOLOGY_TERM2);
+
+        DifferentialExperiment experiment =
+                new DifferentialExperiment(
+                        EXPERIMENT_ACCESSION,
+                        new Date(),
+                        ImmutableList.of(Pair.of(contrast1, true)),
+                        "description",
+                        new Species("species", SpeciesProperties.UNKNOWN),
+                        ImmutableSet.of(),
+                        ImmutableSet.of(),
+                        experimentDesign);
+
+        this.subject = new DifferentialExperimentContrastLines(experiment);
+
+        Iterator<String[]> lines = subject.iterator();
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, CHARACTERISTIC, SAMPLE_HEADER,
+                        SAMPLE_VALUE2, SAMPLE_ONTOLOGY_ID2}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, FACTOR, FACTOR_HEADER, FACTOR_VALUE1,
+                        HTTP_OBO + FACTOR_ONTOLOGY_ID1}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE1,
+                        HTTP_OBO + SAMPLE_ONTOLOGY_ID1}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE4, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, FACTOR, FACTOR_HEADER,
+                        FACTOR_VALUE2, FACTOR_ONTOLOGY_ID2}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE3, ""}));
+    }
+
+    @Test
+    public void duplicateContrastDetailLines() {
+        AssayGroup referenceAssayGroup =
+                new AssayGroup(
+                        "g1",
+                        ImmutableSet.of(new BiologicalReplicate(ASSAY1), new BiologicalReplicate(ASSAY2)));
+        AssayGroup testAssayGroup =
+                new AssayGroup(
+                        "g2",
+                        ImmutableSet.of(new BiologicalReplicate(ASSAY3), new BiologicalReplicate(ASSAY4)));
+        Contrast contrast1 =
+                new Contrast(
+                        CONTRAST_ID, "array design accession", referenceAssayGroup, testAssayGroup, "display name");
+
+        ExperimentDesign experimentDesign = new ExperimentDesign();
+        //This group is for Reference Assay (added two same assay to the group)
+        experimentDesign.putSampleCharacteristic(ASSAY1, SAMPLE_HEADER, SAMPLE_VALUE1);
+        experimentDesign.putFactor(ASSAY1, FACTOR_HEADER, FACTOR_VALUE1);
+
+        experimentDesign.putSampleCharacteristic(ASSAY2, SAMPLE_HEADER, SAMPLE_VALUE1);
+        experimentDesign.putFactor(ASSAY2, FACTOR_HEADER, FACTOR_VALUE1);
+
+        //This group is for Test Assay
+        experimentDesign.putSampleCharacteristic(ASSAY3, SAMPLE_HEADER, SAMPLE_VALUE3);
+        experimentDesign.putFactor(ASSAY3, FACTOR_HEADER, FACTOR_VALUE2);
+        experimentDesign.putSampleCharacteristic(ASSAY4, SAMPLE_HEADER, SAMPLE_VALUE4);
+        experimentDesign.putFactor(ASSAY4, FACTOR_HEADER, FACTOR_VALUE2);
+
+        //Adding the contrasts
+        DifferentialExperiment experiment =
+                new DifferentialExperiment(
+                        EXPERIMENT_ACCESSION,
+                        new Date(),
+                        ImmutableList.of(Pair.of(contrast1, true)),
+                        "description",
+                        new Species("species", SpeciesProperties.UNKNOWN),
+                        ImmutableSet.of(),
+                        ImmutableSet.of(),
+                        experimentDesign);
+
+        this.subject = new DifferentialExperimentContrastLines(experiment);
+
+        Iterator<String[]> lines = subject.iterator();
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE1,
+                        ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, FACTOR, FACTOR_HEADER, FACTOR_VALUE1, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE4, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, FACTOR, FACTOR_HEADER, FACTOR_VALUE2, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE3, ""}));
+    }
+
+    @Test
+    public void emptyValuesDetailLines() {
+        AssayGroup referenceAssayGroup =
+                new AssayGroup(
+                        "g1",
+                        ImmutableSet.of(new BiologicalReplicate(ASSAY1), new BiologicalReplicate(ASSAY2)));
+        AssayGroup testAssayGroup =
+                new AssayGroup(
+                        "g2",
+                        ImmutableSet.of(new BiologicalReplicate(ASSAY3), new BiologicalReplicate(ASSAY4)));
+        Contrast contrast1 =
+                new Contrast(
+                        CONTRAST_ID, "array design accession", referenceAssayGroup, testAssayGroup, "display name");
+
+        ExperimentDesign experimentDesign = new ExperimentDesign();
+        //This group is for Reference Assay (added two same assay to the group)
+        experimentDesign.putSampleCharacteristic(ASSAY1, SAMPLE_HEADER, "");
+        experimentDesign.putFactor(ASSAY1, FACTOR_HEADER, FACTOR_VALUE1);
+
+        experimentDesign.putSampleCharacteristic(ASSAY2, SAMPLE_HEADER, SAMPLE_VALUE2);
+        experimentDesign.putFactor(ASSAY2, FACTOR_HEADER, FACTOR_VALUE1);
+
+        //This group is for Test Assay
+        experimentDesign.putSampleCharacteristic(ASSAY3, SAMPLE_HEADER, SAMPLE_VALUE3);
+        experimentDesign.putFactor(ASSAY3, FACTOR_HEADER, FACTOR_VALUE2);
+        experimentDesign.putSampleCharacteristic(ASSAY4, SAMPLE_HEADER, SAMPLE_VALUE4);
+        experimentDesign.putFactor(ASSAY4, FACTOR_HEADER, FACTOR_VALUE2);
+
+        //Adding the contrasts
+        DifferentialExperiment experiment =
+                new DifferentialExperiment(
+                        EXPERIMENT_ACCESSION,
+                        new Date(),
+                        ImmutableList.of(Pair.of(contrast1, true)),
+                        "description",
+                        new Species("species", SpeciesProperties.UNKNOWN),
+                        ImmutableSet.of(),
+                        ImmutableSet.of(),
+                        experimentDesign);
+
+        this.subject = new DifferentialExperimentContrastLines(experiment);
+
+        Iterator<String[]> lines = subject.iterator();
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE2,
+                        ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, FACTOR, FACTOR_HEADER, FACTOR_VALUE1, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, REFERENCE, CHARACTERISTIC, SAMPLE_HEADER, "", ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE4, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, FACTOR, FACTOR_HEADER, FACTOR_VALUE2, ""}));
+
+        assertThat(
+                lines.next(),
+                is(new String[] {
+                        EXPERIMENT_ACCESSION, CONTRAST_ID, TEST, CHARACTERISTIC, SAMPLE_HEADER, SAMPLE_VALUE3, ""}));
+    }
+}


### PR DESCRIPTION
Funny story! EBI Search no longer use these endpoints, but we do!