### PR TITLE
Bugfix - Extra space after Assay header in experiment design file

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experimentimport/experimentdesign/ExperimentDesignFileWriter.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentimport/experimentdesign/ExperimentDesignFileWriter.java
@@ -77,7 +77,7 @@ public class ExperimentDesignFileWriter {
             case PROTEOMICS_BASELINE:
                 return Lists.newArrayList("Run");
             case SINGLE_CELL_RNASEQ_MRNA_BASELINE:
-                return Lists.newArrayList("Assay ");
+                return Lists.newArrayList("Assay");
             default:
                 throw new IllegalArgumentException("Invalid parent type: " + type.getParent());
         }


### PR DESCRIPTION
Removed unnecessary space added after the Assay header in the experiment design file.