### PR TITLE
Feature #161749807 - Add support for link in the CardModel description

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModel.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModel.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public abstract class CardModel {
     public abstract CardIconType iconType();
     public abstract String iconSrc();
-    public abstract Optional<String> iconDescription();
+    public abstract Optional<Pair<String, Optional<String>>> description();
     public abstract List<Pair<String, Optional<String>>> content();
 
     public static CardModel create(CardIconType iconType,
@@ -26,12 +26,12 @@ public abstract class CardModel {
 
     public static CardModel create(CardIconType iconType,
                                    String iconSrc,
-                                   String iconDescription,
+                                   Pair<String, Optional<String>> description,
                                    List<Pair<String, Optional<String>>> content) {
         return new AutoValue_CardModel(
                 iconType,
                 iconSrc,
-                Optional.of(iconDescription),
+                Optional.of(description),
                 content
         );
     }

--- a/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModelAdapter.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModelAdapter.java
@@ -14,8 +14,10 @@ public class CardModelAdapter {
         result.addProperty("iconType", cardModel.iconType().name().toLowerCase());
         result.addProperty("iconSrc", cardModel.iconSrc());
 
-        cardModel.iconDescription().ifPresent(
-                description -> result.addProperty("iconDescription", cardModel.iconDescription().get()));
+        cardModel.description().ifPresent(
+                description ->
+                    result.add("description",
+                            getTextAndUrl(description.getLeft(), description.getRight())));
 
         if (cardModel.content().size() != 0) {
             result.add("content", getContent(cardModel.content()));
@@ -36,7 +38,7 @@ public class CardModelAdapter {
         JsonArray content = new JsonArray();
 
         textAndUrls.forEach(textAndUrl -> content.add(
-                getTextAndUrlAsJson(
+                getTextAndUrl(
                         textAndUrl.getLeft(),
                         textAndUrl.getRight()
                 )));
@@ -44,7 +46,7 @@ public class CardModelAdapter {
         return content;
     }
 
-    private static JsonObject getTextAndUrlAsJson(String text, Optional<String> url) {
+    private static JsonObject getTextAndUrl(String text, Optional<String> url) {
         JsonObject textAndUrl = new JsonObject();
         textAndUrl.addProperty("text", text);
         url.ifPresent(s -> textAndUrl.addProperty("url", s));

--- a/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModelFactory.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModelFactory.java
@@ -15,10 +15,11 @@ public class CardModelFactory {
         return CardModel.create(
                 CardIconType.SPECIES,
                 popularSpeciesInfo.species(),
-                StringUtils.capitalize(popularSpeciesInfo.species()),
+                Pair.of(StringUtils.capitalize(popularSpeciesInfo.species()),
+                        Optional.of(getExperimentsFilteredBySpeciesUrl(popularSpeciesInfo.species()))),
                 Collections.singletonList(
                         Pair.of(popularSpeciesInfo.totalExperiments() + " experiments",
-                                Optional.of(getExperimentsFilteredBySpeciesUrl(popularSpeciesInfo.species()))))
+                                Optional.empty()))
                 );
     }
 

--- a/base/src/test/java/uk/ac/ebi/atlas/model/card/CardModelAdapterTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/model/card/CardModelAdapterTest.java
@@ -35,7 +35,7 @@ public class CardModelAdapterTest {
 
         assertThat(result.has("iconType")).isTrue();
         assertThat(result.has("iconSrc")).isTrue();
-        assertThat(result.has("iconDescription")).isFalse();
+        assertThat(result.has("description")).isFalse();
         assertThat(result.has("content")).isFalse();
     }
 
@@ -45,7 +45,7 @@ public class CardModelAdapterTest {
 
         JsonObject result = CardModelAdapter.serialize(cardModel);
 
-        assertThat(result.has("iconDescription")).isTrue();
+        assertThat(result.has("description")).isTrue();
 
         JsonArray contentResult = result.get("content").getAsJsonArray();
         assertThat(contentResult.size()).isEqualTo(3);
@@ -120,7 +120,7 @@ public class CardModelAdapterTest {
         }
 
         if (hasDescription) {
-            return CardModel.create(iconType, iconSrc, randomAlphabetic(10), content);
+            return CardModel.create(iconType, iconSrc, Pair.of(randomAlphabetic(10), Optional.empty()), content);
         }
         else {
             return CardModel.create(iconType, iconSrc, content);

--- a/sc/src/test/java/uk/ac/ebi/atlas/home/JsonPopularSpeciesControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/home/JsonPopularSpeciesControllerWIT.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -84,10 +85,12 @@ public class JsonPopularSpeciesControllerWIT {
                 .andExpect(jsonPath("$", hasSize(greaterThanOrEqualTo(1))))
                 .andExpect(jsonPath("$.[*].iconType").exists())
                 .andExpect(jsonPath("$.[*].iconSrc").exists())
-                .andExpect(jsonPath("$.[*].iconDescription").exists())
+                .andExpect(jsonPath("$.[*].description").exists())
+                .andExpect(jsonPath("$.[*].description.text").exists())
+                .andExpect(jsonPath("$.[*].description.url").exists())
                 .andExpect(jsonPath("$.[*].content").exists())
                 .andExpect(jsonPath("$.[*].content.[*].text").exists())
-                .andExpect(jsonPath("$.[*].content.[*].url").exists());
+                .andExpect(jsonPath("$.[*].content.[*].url").doesNotExist());
     }
 
     @Test

--- a/sc/src/test/java/uk/ac/ebi/atlas/home/JsonPopularSpeciesControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/home/JsonPopularSpeciesControllerWIT.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;


### PR DESCRIPTION
- Changed CardModel description from a string to a pair containing text and an optional URL. 
- Changed the adapter class to convert the pair into a JSON object.
- Changed related tests.