### PR TITLE
Bugfix #161845714 - Marker gene links not always correct

### DIFF
--- a/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchDao.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchDao.java
@@ -28,7 +28,7 @@ import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollecti
 @Component
 public class GeneSearchDao {
     private static final Logger LOGGER = LoggerFactory.getLogger(GeneSearchDao.class);
-    private static final double MARKER_GENE_P_VALUE_THRESHOLD = 0.005;
+    private static final double MARKER_GENE_P_VALUE_THRESHOLD = 0.05;
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private SingleCellAnalyticsCollectionProxy singleCellAnalyticsCollectionProxy;
@@ -71,12 +71,12 @@ public class GeneSearchDao {
     }
 
     private static final String SELECT_EXPERIMENT_ACCESSION_FOR_GENE_ID =
-            "SELECT experiment_accession FROM scxa_marker_genes AS markers "+
-            "JOIN scxa_experiment AS experiments ON markers.experiment_accession = experiments.accession "+
-            "WHERE private=FALSE AND gene_id=:gene_id "+
+            "SELECT experiment_accession FROM scxa_marker_genes AS markers " +
+            "JOIN scxa_experiment AS experiments ON markers.experiment_accession = experiments.accession " +
+            "WHERE private=FALSE AND gene_id=:gene_id " +
             "GROUP BY experiment_accession";
     @Transactional(readOnly = true)
-    public List<String> experimentAccessionsForGeneId (String geneId) {
+    public List<String> experimentAccessionsForGeneId(String geneId) {
         Map<String, Object> namedParameters =
                 ImmutableMap.of(
                         "gene_id", geneId);
@@ -84,9 +84,9 @@ public class GeneSearchDao {
         return namedParameterJdbcTemplate.query(
                 SELECT_EXPERIMENT_ACCESSION_FOR_GENE_ID,
                 namedParameters,
-                (ResultSet resultSet)->{
+                (ResultSet resultSet) -> {
                     List<String> result = new ArrayList<>();
-                    while(resultSet.next()){
+                    while (resultSet.next()) {
                         String experimentAccession = resultSet.getString("experiment_accession");
                         result.add(experimentAccession);
                     }
@@ -95,22 +95,19 @@ public class GeneSearchDao {
         );
     }
 
-
-    //In marker gene dataset files, one and only one clusterID for each preferred cluster K value,
-    //which is supposed to have the lowest marker_probability,
-    //so we get one pair from searching (experiment_accesion, k).
-    //If dataset has changed, i.e. there are multiple gene clusterID in one preferred cluster K file,
-    //we probably need to order and limit the searching result based on marker_propability
+    // Retrieves cluster IDs the preferred K value (if present), as well as for the minimum p-value. If the minimum
+    // p-value is equal for multiple Ks (and a preferred K is not passed in), all K values will be returned. */
     private static final String SELECT_PREFERREDK_AND_MINP_CLUSTER_ID_FOR_GENE_STATEMENT =
-            "SELECT experiment_accession, k, marker_probability, cluster_id FROM scxa_marker_genes AS markers " +
-                    "WHERE (marker_probability IN (SELECT MIN(marker_probability) "+
-                                                                    "FROM scxa_marker_genes " +
-                                                                    "WHERE gene_id = :gene_id " +
-                                                                    "GROUP BY experiment_accession) " +
-                                                "AND experiment_accession = :experiment_accession " +
-                                                "AND marker_probability <= :threshold) " +
-                    "OR ((experiment_accession, k) IN ((:experiment_accession, :preferred_K)) " +
-                        "AND marker_probability <= :threshold AND gene_id = :gene_id)";
+    "SELECT k, cluster_id FROM scxa_marker_genes AS markers " +
+            "WHERE experiment_accession=:experiment_accession " +
+                "AND gene_id=:gene_id " +
+                "AND marker_probability<:threshold " +
+                "AND ((k is NULL OR k=:preferred_K) " +
+                    "OR marker_probability IN ( " +
+                        "SELECT MIN(marker_probability) " +
+                            "FROM scxa_marker_genes " +
+                            "WHERE markers.experiment_accession = :experiment_accession " +
+                            "AND gene_id=:gene_id))";
     @Transactional(readOnly = true)
     public  Map<Integer, List<Integer>> fetchClusterIdsWithPreferredKAndMinPForExperimentAccession(
             String geneId, String experimentAccession, Integer preferredK) {

--- a/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchDao.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchDao.java
@@ -70,19 +70,19 @@ public class GeneSearchDao {
         );
     }
 
-    private static final String SELECT_EXPERIMENT_ACCESSION_FOR_GENE_ID =
+    private static final String SELECT_EXPERIMENT_ACCESSION_FOR_MARKER_GENE_ID =
             "SELECT experiment_accession FROM scxa_marker_genes AS markers " +
             "JOIN scxa_experiment AS experiments ON markers.experiment_accession = experiments.accession " +
             "WHERE private=FALSE AND gene_id=:gene_id " +
             "GROUP BY experiment_accession";
     @Transactional(readOnly = true)
-    public List<String> experimentAccessionsForGeneId(String geneId) {
+    public List<String> fetchExperimentAccessionsWhereGeneIsMarker(String geneId) {
         Map<String, Object> namedParameters =
                 ImmutableMap.of(
                         "gene_id", geneId);
 
         return namedParameterJdbcTemplate.query(
-                SELECT_EXPERIMENT_ACCESSION_FOR_GENE_ID,
+                SELECT_EXPERIMENT_ACCESSION_FOR_MARKER_GENE_ID,
                 namedParameters,
                 (ResultSet resultSet) -> {
                     List<String> result = new ArrayList<>();

--- a/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchService.java
@@ -49,7 +49,9 @@ public class GeneSearchService {
 
         return fetchInParallel(
                 ImmutableSet.copyOf(geneIds),
-                geneId -> fetchClusterIDWithPreferredKAndMinPForGeneID(geneSearchDao.experimentAccessionsForGeneId(geneId), geneId));
+                geneId -> fetchClusterIDWithPreferredKAndMinPForGeneID(
+                        geneSearchDao.fetchExperimentAccessionsWhereGeneIsMarker(geneId),
+                        geneId));
     }
 
     private <T> Map<String, T> fetchInParallel(Set<String> geneIds, Function<String, T> geneIdInfoProvider) {

--- a/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/GeneSearchService.java
@@ -73,17 +73,18 @@ public class GeneSearchService {
         }
     }
 
-    public  Map<String, Map<Integer, List<Integer>>> fetchClusterIDWithPreferredKAndMinPForGeneID (List<String> experimentAccessions, String geneId){
+    public Map<String, Map<Integer, List<Integer>>> fetchClusterIDWithPreferredKAndMinPForGeneID(List<String> experimentAccessions, String geneId) {
         Map<String, Map<Integer, List<Integer>>> result = new HashMap<>();
 
         for (String experimentAccession : experimentAccessions) {
             Optional<Integer> preferredK = tsnePlotSettingsService.getExpectedClusters(experimentAccession);
-            if (preferredK.isPresent()) {
-                Map<Integer, List<Integer>> clusterIDWithPreferredKAndMinP = geneSearchDao.fetchClusterIdsWithPreferredKAndMinPForExperimentAccession
-                        (geneId, experimentAccession, preferredK.get());
-                if(!clusterIDWithPreferredKAndMinP.isEmpty()){
-                    result.put(experimentAccession, clusterIDWithPreferredKAndMinP);
-                }
+            Map<Integer, List<Integer>> clusterIDWithPreferredKAndMinP =
+                    geneSearchDao.fetchClusterIdsWithPreferredKAndMinPForExperimentAccession(
+                            geneId,
+                            experimentAccession,
+                            preferredK.orElse(null));
+            if (!clusterIDWithPreferredKAndMinP.isEmpty()) {
+                result.put(experimentAccession, clusterIDWithPreferredKAndMinP);
             }
         }
         return result;

--- a/sc/src/test/java/uk/ac/ebi/atlas/search/GeneSearchDaoIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/search/GeneSearchDaoIT.java
@@ -90,7 +90,7 @@ class GeneSearchDaoIT {
     @ParameterizedTest
     @ValueSource(strings = {"ENSMUSG00000063415"})
     void validGeneIdReturnsExperimentAccessions(String geneId) {
-        List<String> result = subject.experimentAccessionsForGeneId(geneId);
+        List<String> result = subject.fetchExperimentAccessionsWhereGeneIsMarker(geneId);
 
         assertThat(result)
                 .containsOnly("E-GEOD-99058");
@@ -99,7 +99,7 @@ class GeneSearchDaoIT {
     @ParameterizedTest
     @ValueSource(strings = {"FOO"})
     void invalidGeneIdReturnsEmpty(String geneId) {
-        assertThat(subject.experimentAccessionsForGeneId(geneId))
+        assertThat(subject.fetchExperimentAccessionsWhereGeneIsMarker(geneId))
                 .isEmpty();
     }
 

--- a/sc/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
@@ -118,7 +118,7 @@ class GeneSearchServiceTest {
                 .thenReturn(ImmutableMap.of(10, ImmutableList.of(1)));
 
         when(geneSearchDaoMock
-                .experimentAccessionsForGeneId(geneID))
+                .fetchExperimentAccessionsWhereGeneIsMarker(geneID))
                 .thenReturn(ImmutableList.of(experimentAccession1, experimentAccession2));
 
         Map<String, Map<String, Map<Integer, List<Integer>>>> result = subject.getMarkerGeneProfile(geneID);
@@ -161,9 +161,9 @@ class GeneSearchServiceTest {
                 .fetchClusterIdsWithPreferredKAndMinPForExperimentAccession(geneID2, experimentAccession4, 4))
                 .thenReturn(ImmutableMap.of(4, ImmutableList.of(1)));
 
-        when(geneSearchDaoMock.experimentAccessionsForGeneId(geneID1))
+        when(geneSearchDaoMock.fetchExperimentAccessionsWhereGeneIsMarker(geneID1))
                 .thenReturn(ImmutableList.of(experimentAccession1, experimentAccession2));
-        when(geneSearchDaoMock.experimentAccessionsForGeneId(geneID2))
+        when(geneSearchDaoMock.fetchExperimentAccessionsWhereGeneIsMarker(geneID2))
                 .thenReturn(ImmutableList.of(experimentAccession3, experimentAccession4));
 
         assertThat(subject.getMarkerGeneProfile(geneID1, geneID2))


### PR DESCRIPTION
- Fixed issue where ks and cluster IDs were retrieved for all the genes in any experiment that happened to have the minimum p-value
- Fixed issue where marker genes weren't retrieved at all for experiments that don't have a preferred K
- Incresed marker gene threshold back up to 0.05
- Fixed minor code style issues and improved method naming even further

At the moment, this code will retrieve all the ks and cluster IDs where that gene has the minimum p-value. One way to mitigate this is to only retrieve the cluster ID for the preferred K. The issue is what happens when we don't have a preferred K... Do we retrieve the first K or do we show all of them?