### PR TITLE
Feature #160482938 – Go back to the old ontology IDs in the JSON OT dump

### DIFF
--- a/gxa/src/main/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/EvidenceService.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/EvidenceService.java
@@ -49,6 +49,7 @@ EvidenceService<
         P extends Profile<Contrast, X, P>> {
 
     private static final double MIN_P_VALUE = 1e-234;
+    private static final String ACTIVITY_URL_TEMPLATE= "http://identifiers.org/cttv.activity/{0}";
 
     private final ProfileStreamFactory<Contrast, X, E, O, P> differentialProfileStreamFactory;
     private final DataFileHub dataFileHub;
@@ -363,13 +364,13 @@ EvidenceService<
     private String activity(boolean isCttvPrimary, X expression) {
         if (isCttvPrimary) {
             if (expression.getFoldChange() > 0) {
-                return "http://purl.obolibrary.org/obo/SO_0001542";
+                return MessageFormat.format(ACTIVITY_URL_TEMPLATE, "increased_transcript_level");
             } else if (expression.getFoldChange() < 0) {
-                return "http://purl.obolibrary.org/obo/SO_0001541";
+                return MessageFormat.format(ACTIVITY_URL_TEMPLATE, "decreased_transcript_level");
             }
         }
 
-        return "http://identifiers.org/cttv.activity/unknown";
+        return MessageFormat.format(ACTIVITY_URL_TEMPLATE, "unknown");
     }
 
     private JsonObject target(String ensemblGeneId, boolean isCttvPrimary, X expression) {


### PR DESCRIPTION
Reverts 20fcffb5d334bd3ac1a720c36b331f2d664f243d.