### PR TITLE
Feature #161607744 – Suggest two char symbols

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>atlas-core</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>Atlas Core</name>

--- a/base/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterDao.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterDao.java
@@ -7,6 +7,7 @@ import uk.ac.ebi.atlas.solr.bioentities.query.BioentitiesSolrClient;
 import uk.ac.ebi.atlas.species.Species;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -39,17 +40,23 @@ public class SuggesterDao {
                                                 String query,
                                                 int limit,
                                                 Species... species) {
-        // Solr suggesters return suggestions if cfq is set, even when the query doesn’t reach the minimum length
-        if (query.length() < 3) {
+        // We want the user to go beyond one keystroke to get some suggestions
+        if (query.length() < 2) {
             return Stream.empty();
         }
+
+        Comparator<Suggestion> compareByWeightLengthAlphabetical =
+                Comparator
+                        .comparingLong(Suggestion::getWeight).reversed()
+                        .thenComparingInt(suggestion -> suggestion.getTerm().length())
+                        .thenComparing(Suggestion::getTerm);
 
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setRequestHandler("/suggest")
                 .setParam("suggest.dictionary", suggesterDictionary)
-                // We don’t set suggest.count because we want unique suggestions, see distinct() below
-                // .setParam("suggest.count", Integer.toString(limit))
                 .setParam("suggest.q", query)
+                // We raise suggest.count to a high enough value to get exact matches (the default is 100)
+                .setParam("suggest.count", "500")
                 .setParam(
                         "suggest.cfq",
                         Arrays.stream(species)
@@ -59,9 +66,10 @@ public class SuggesterDao {
         return solrClient.query(solrQuery).getSuggesterResponse().getSuggestions().values().stream()
                 .flatMap(List::stream)
                 // The current implementation considers symbols Aspm and ASPM two different suggestions. I dont’t know
-                // if that’s good or bad because I dont’t know if to a biologist it’s meaningful (I guess not). If we
+                // if that’s good or bad because I don’t know if to a biologist it’s meaningful (I guess not). If we
                 // change it it should be reflected in a story.
                 .distinct()
+                .sorted(compareByWeightLengthAlphabetical)
                 .limit(limit);
     }
 }

--- a/base/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterDao.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterDao.java
@@ -56,7 +56,7 @@ public class SuggesterDao {
                 .setParam("suggest.dictionary", suggesterDictionary)
                 .setParam("suggest.q", query)
                 // We raise suggest.count to a high enough value to get exact matches (the default is 100)
-                .setParam("suggest.count", "500")
+                .setParam("suggest.count", "750")
                 .setParam(
                         "suggest.cfq",
                         Arrays.stream(species)

--- a/base/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterService.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterService.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 @Component
 public class SuggesterService {
     // Remember that suggestions are distinct()’ed, so this value is an upper bound
-    public static final int DEFAULT_MAX_NUMBER_OF_SUGGESTIONS = 20;
+    public static final int DEFAULT_MAX_NUMBER_OF_SUGGESTIONS = 10;
 
     private static final Function<Suggestion, Map<String, String>>
     SUGGESTION_TO_MAP =

--- a/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
@@ -70,14 +70,15 @@ class SuggesterDaoIT {
     }
 
     @Test
-    void atLeastThreeCharactersRequired() {
-        assertThat(subject.fetchBioentityProperties("as", 10, false))
+    void atLeastTwoCharactersRequired() {
+        assertThat(subject.fetchBioentityProperties("a", 10, false))
                 .isEmpty();
-        assertThat(subject.fetchBioentityProperties("as", 10, false, speciesUtils.getHuman()))
+        assertThat(subject.fetchBioentityProperties("a", 10, false, speciesUtils.getHuman()))
                 .isEmpty();
-        assertThat(subject.fetchBioentityProperties("asp", 10, false))
+
+        assertThat(subject.fetchBioentityProperties("ar", 10, false))
                 .isNotEmpty();
-        assertThat(subject.fetchBioentityProperties("asp", 10, false, speciesUtils.getHuman()))
+        assertThat(subject.fetchBioentityProperties("ar", 10, false, speciesUtils.getHuman()))
                 .isNotEmpty();
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
@@ -91,7 +91,7 @@ class SuggesterDaoIT {
         String twoCharSymbol = "AR";
 
         // Suggestion::equals is established only by term and payload, weight isn’t considered
-        assertThat(subject.fetchBioentityProperties(twoCharSymbol.toLowerCase(), 10, false))
+        assertThat(subject.fetchBioentityProperties(twoCharSymbol, 10, false))
                 .isNotEmpty()
                 .startsWith(new Suggestion(twoCharSymbol, 0, "symbol"));
         assertThat(subject.fetchBioentityProperties("ar", 10, false, speciesUtils.getHuman()))

--- a/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.search.suggester;
 
+import org.apache.solr.client.solrj.response.Suggestion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -80,5 +81,18 @@ class SuggesterDaoIT {
                 .isNotEmpty();
         assertThat(subject.fetchBioentityProperties("ar", 10, false, speciesUtils.getHuman()))
                 .isNotEmpty();
+    }
+
+    @Test
+    void closestMatchIsFirst() {
+        String twoCharSymbol = "AR";
+
+        // Suggestion::equals is established only by term and payload, weight isn’t considered
+        assertThat(subject.fetchBioentityProperties(twoCharSymbol.toLowerCase(), 10, false))
+                .isNotEmpty()
+                .startsWith(new Suggestion(twoCharSymbol, 0, "symbol"));
+        assertThat(subject.fetchBioentityProperties("ar", 10, false, speciesUtils.getHuman()))
+                .isNotEmpty()
+                .startsWith(new Suggestion(twoCharSymbol, 0, "symbol"));
     }
 }

--- a/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
@@ -10,6 +10,7 @@ import uk.ac.ebi.atlas.testutils.SpeciesUtils;
 
 import javax.inject.Inject;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
@@ -31,9 +32,11 @@ class SuggesterDaoIT {
     }
 
     @Test
-    void duplicatesAreRemoved() {
-        assertThat(subject.fetchBioentityProperties("asp", 100, false).count())
-                .isLessThan(100);
+    void doesNotContainDuplicates() {
+        String query = randomAlphabetic(3, 4);
+
+        assertThat(subject.fetchBioentityProperties(query.toLowerCase(), 100, false).count())
+                .isEqualTo(subject.fetchBioentityProperties(query.toLowerCase(), 100, false).distinct().count());
     }
 
     @Test

--- a/gxa/pom.xml
+++ b/gxa/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>uk.ac.ebi.atlas</groupId>
             <artifactId>atlas-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.1</version>
         </dependency>
 
         <!-- For URL rewrite (see WEB-INF/web.xml) -->

--- a/sc/pom.xml
+++ b/sc/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>uk.ac.ebi.atlas</groupId>
             <artifactId>atlas-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Besides the code changes, I removed the English stop words: `solr/admin/zookeeper?detail=true&path=%2Fconfigs%2Fbioentities%2Flang%2Fstopwords_en.txt`. There are many such as *the*, *in*, *as*... that return results. This is an infrastructure change that we need to propagate to other environments if we want results from these queries (it’s not critical since Laura is only interested in AR ;) ).