### PR TITLE
Bugfix #162342970 – Search within the experiment page always returns no results

### DIFF
--- a/atlas-misc/solr/analytics-schema.production.sh
+++ b/atlas-misc/solr/analytics-schema.production.sh
@@ -415,7 +415,7 @@ printf "\n\nCreate dynamic rule keyword_* (string, multiValued)"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-dynamic-field": {
      "name": "keyword_*",
-     "type": "string",
+     "type": "lowercase",
      "multiValued": true}
 }' http://$HOST/solr/$CORE/schema
 


### PR DESCRIPTION
Some time ago I changed the dynamic `keyword_*` type to string. I have no idea why. D: