### PR TITLE
Bugfix/162416247 add empty array if null marker genes

### DIFF
--- a/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -160,7 +160,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
                                                 markerGeneFacets.get(geneId).get(experimentAccession)));
                             } else {
                                 experimentAttributes.put(
-                                        "markerGenes", new ArrayList());
+                                        "markerGenes", ImmutableList.of());
                             }
 
                             return ImmutableMap.of("element", experimentAttributes, "facets", facets);

--- a/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -158,6 +158,9 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
                                                 experimentAccession,
                                                 geneId,
                                                 markerGeneFacets.get(geneId).get(experimentAccession)));
+                            }else{
+                                experimentAttributes.put(
+                                        "markerGenes", new ArrayList());
                             }
 
                             return ImmutableMap.of("element", experimentAttributes, "facets", facets);

--- a/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -158,7 +158,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
                                                 experimentAccession,
                                                 geneId,
                                                 markerGeneFacets.get(geneId).get(experimentAccession)));
-                            }else{
+                            } else {
                                 experimentAttributes.put(
                                         "markerGenes", new ArrayList());
                             }
@@ -196,7 +196,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
                     .put("value", entry.getValue())
                     .put("label", StringUtils.capitalize(entry.getValue()));
 
-            if(!isNullOrEmpty(getTooltipText(entry.getKey()))) {
+            if (!isNullOrEmpty(getTooltipText(entry.getKey()))) {
                 mapBuilder.put("description", getTooltipText(entry.getKey()));
             }
 
@@ -207,7 +207,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
 
     private String getTooltipText(String group) {
         for (FacetsToTooltipMapping tooltip : FacetsToTooltipMapping.values()) {
-            if(tooltip.getTitle().equalsIgnoreCase(group)) {
+            if (tooltip.getTitle().equalsIgnoreCase(group)) {
                return tooltip.getTooltip();
             }
         }

--- a/sc/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
@@ -113,6 +113,7 @@ class JsonGeneSearchControllerWIT {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.results", hasSize(greaterThanOrEqualTo(1))))
                 .andExpect(jsonPath("$.results[0].element.experimentAccession", isA(String.class)))
+                .andExpect(jsonPath("$.results[0].element.markerGenes", hasSize(greaterThanOrEqualTo(0))))
                 .andExpect(jsonPath("$.results[0].facets", hasSize(greaterThanOrEqualTo(1))))
                 .andExpect(jsonPath("$.results[0].facets[0].group", isA(String.class)))
                 .andExpect(jsonPath("$.results[0].facets[0].value", isA(String.class)))


### PR DESCRIPTION
To make SC facet search results table header sorting works well, I add an empty array for null markerGenes attribute. It will not affect the existed work, but make sure the sorting is enabled all the time, since I check if a header is included in the response attributes.