### PR TITLE
Bugfix #164247133 – Fix pluralisation in species experiment cards

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModelFactory.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/model/card/CardModelFactory.java
@@ -25,15 +25,26 @@ public class CardModelFactory {
 
     public CardModel create(PopularSpeciesInfo popularSpeciesInfo) {
         List<Pair<String, Optional<String>>> content = new ArrayList<>();
-        content.add(Pair.of(popularSpeciesInfo.totalExperiments() + " experiments",
-                Optional.empty()));
-        if(popularSpeciesInfo.baselineExperiments() > 0){
-            content.add(Pair.of("Baseline:" + popularSpeciesInfo.baselineExperiments(),
-                Optional.of(urlHelpers.getExperimentsFilteredBySpeciesAndExperimentType(popularSpeciesInfo.species(), "baseline"))));
+        content.add(
+                Pair.of(popularSpeciesInfo.totalExperiments() + " experiment" +
+                                (popularSpeciesInfo.totalExperiments() > 1 ? "s" : ""),
+                        Optional.empty()));
+
+        if (popularSpeciesInfo.baselineExperiments() > 0) {
+            content.add(
+                    Pair.of("Baseline: " + popularSpeciesInfo.baselineExperiments(),
+                            Optional.of(
+                                    urlHelpers.getExperimentsFilteredBySpeciesAndExperimentType(
+                                            popularSpeciesInfo.species(),
+                                            "baseline"))));
         }
-        if(popularSpeciesInfo.differentialExperiments() > 0){
-            content.add(Pair.of("Differential:" + popularSpeciesInfo.differentialExperiments() + " ",
-                Optional.of(urlHelpers.getExperimentsFilteredBySpeciesAndExperimentType(popularSpeciesInfo.species(), "differential"))));
+        if (popularSpeciesInfo.differentialExperiments() > 0) {
+            content.add(
+                    Pair.of("Differential: " + popularSpeciesInfo.differentialExperiments(),
+                            Optional.of(
+                                    urlHelpers.getExperimentsFilteredBySpeciesAndExperimentType(
+                                            popularSpeciesInfo.species(),
+                                            "differential"))));
         }
 
         return CardModel.create(

--- a/base/src/test/java/uk/ac/ebi/atlas/model/card/CardModelFactoryTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/model/card/CardModelFactoryTest.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -50,7 +51,6 @@ class CardModelFactoryTest {
         subject = new CardModelFactory(urlHelpersImpl);
     }
 
-
     @Test
     void createPopularSpeciesCard() {
         Species species = generateRandomSpecies();
@@ -68,6 +68,48 @@ class CardModelFactoryTest {
 
         assertThat(subject.create(someWeirdSpeciesInfo).content())
                 .hasSize(3);
+    }
+
+    @Test
+    void experimentWordIsPluralisedInSpeciesCards() {
+        assertThat(
+                subject.create(
+                        PopularSpeciesInfo.create(
+                                randomAlphabetic(10),
+                                randomAlphabetic(10),
+                                0,
+                                1))
+                        .content().get(0).getLeft())
+                .endsWith("experiment");
+
+        assertThat(
+                subject.create(
+                        PopularSpeciesInfo.create(
+                                randomAlphabetic(10),
+                                randomAlphabetic(10),
+                                1))
+                        .content().get(0).getLeft())
+                .endsWith("experiment");
+
+
+        assertThat(
+                subject.create(
+                        PopularSpeciesInfo.create(
+                                randomAlphabetic(10),
+                                randomAlphabetic(10),
+                                1,
+                                1)).content().get(0).getLeft())
+                .endsWith("experiments");
+
+        assertThat(
+                subject.create(
+                        PopularSpeciesInfo.create(
+                                randomAlphabetic(10),
+                                randomAlphabetic(10),
+                                RNG.nextInt(2, Integer.MAX_VALUE)))
+                        .content().get(0).getLeft())
+                .endsWith("experiments");
+
     }
 
     @Test


### PR DESCRIPTION
Populate the content with the word “experiment” or “experiments” depending on the total experiment count.