### PR TITLE
Feature/164403270 sync json payloads for tsnes

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/experimentpage/tsne/TSnePoint.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/experimentpage/tsne/TSnePoint.java
@@ -55,6 +55,10 @@ public abstract class TSnePoint {
         return new AutoValue_TSnePoint(x, y, Optional.empty(), name, "");
     }
 
+    public static TSnePoint create(double x, double y, double expressionLevel, String name, String metadata) {
+        return new AutoValue_TSnePoint(x, y, Optional.of(expressionLevel), name, metadata);
+    }
+
     public static TSnePoint create(double x, double y, String name, String metadata) {
         return new AutoValue_TSnePoint(x, y, Optional.empty(), name, metadata);
     }

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -96,6 +96,18 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
     }
 
     @RequestMapping(
+            value =  "/json/experiments/{experimentAccession}/tsneplot/{perplexity}/clusters/k/{k}/expression",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String pointsWithExpressionAndClusters(
+            @PathVariable String experimentAccession,
+            @PathVariable int perplexity,
+            @PathVariable int k,
+            @RequestParam(defaultValue = "") String accessKey) {
+        return tSnePlotExpressionsWithClusters(experimentAccession, perplexity, k, "", accessKey);
+    }
+
+    @RequestMapping(
             value = "/json/experiments/{experimentAccession}/tsneplot/{perplexity}/metadata/{metadata}",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
@@ -160,6 +172,17 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
         return GSON.toJson(model);
     }
 
+    @RequestMapping(
+            value =  "/json/experiments/{experimentAccession}/tsneplot/{perplexity}/metadata/{metadata}/expression",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String tSnePlotExpressionsWithMetadata(
+            @PathVariable String experimentAccession,
+            @PathVariable int perplexity,
+            @PathVariable String metadata,
+            @RequestParam(defaultValue = "") String accessKey) {
+        return tSnePlotExpressionsWithMetadata(experimentAccession, perplexity, "", accessKey);
+    }
 
     private List<Map<String, Object>> modelForHighcharts(String seriesNamePrefix, Map<?, Set<TSnePoint>> points) {
         return points.entrySet().stream()

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -54,6 +54,26 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
                                 tSnePlotService.fetchTSnePlotWithClusters(experiment.getAccession(), perplexity, k))));
     }
 
+
+    @RequestMapping(
+            value = "/json/experiments/{experimentAccession}/tsneplot/{perplexity}/clusters/k/{k}/expression/{geneId}",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String tSnePlotWithClusters(
+            @PathVariable String experimentAccession,
+            @PathVariable int perplexity,
+            @PathVariable int k,
+            @PathVariable String geneId,
+            @RequestParam(defaultValue = "") String accessKey) {
+        Experiment experiment = experimentTrader.getExperiment(experimentAccession, accessKey);
+        return GSON.toJson(
+                ImmutableMap.of(
+                        "series",
+                        modelForHighcharts(
+                                "Cluster ",
+                                tSnePlotService.fetchTSnePlotWithExpressionAndClusters(experiment.getAccession(), perplexity, geneId, k))));
+    }
+
     @RequestMapping(
             value = "/json/experiments/{experimentAccession}/tsneplot/{perplexity}/expression",
             method = RequestMethod.GET,

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -96,10 +96,10 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
     }
 
     @RequestMapping(
-            value =  "/json/experiments/{experimentAccession}/tsneplot/{perplexity}/clusters/k/{k}/expression",
+            value = "/json/experiments/{experimentAccession}/tsneplot/{perplexity}/clusters/k/{k}/expression",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public String pointsWithExpressionAndClusters(
+    public String tSnePlotExpressionsWithClusters(
             @PathVariable String experimentAccession,
             @PathVariable int perplexity,
             @PathVariable int k,
@@ -181,7 +181,7 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
             @PathVariable int perplexity,
             @PathVariable String metadata,
             @RequestParam(defaultValue = "") String accessKey) {
-        return tSnePlotExpressionsWithMetadata(experimentAccession, perplexity, "", accessKey);
+        return tSnePlotExpressionsWithMetadata(experimentAccession, perplexity, metadata, "", "accessKey");
     }
 
     private List<Map<String, Object>> modelForHighcharts(String seriesNamePrefix, Map<?, Set<TSnePoint>> points) {

--- a/sc/src/main/java/uk/ac/ebi/atlas/tsne/TSnePlotDao.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/tsne/TSnePlotDao.java
@@ -17,31 +17,6 @@ public class TSnePlotDao {
         this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
     }
 
-    private static final String SELECT_T_SNE_PLOT_WITH_EXPRESSION_STATEMENT =
-            "SELECT tsne.cell_id, tsne.x, tsne.y, analytics.expression_level " +
-            "FROM scxa_tsne AS tsne " +
-                "LEFT JOIN " +
-                "(SELECT * FROM scxa_analytics WHERE gene_id=:gene_id) AS analytics " +
-                "ON analytics.cell_id=tsne.cell_id AND analytics.experiment_accession=tsne.experiment_accession " +
-            "WHERE tsne.experiment_accession=:experiment_accession AND tsne.perplexity=:perplexity";
-    @Transactional(transactionManager = "txManager", readOnly = true)
-    public List<TSnePoint.Dto> fetchTSnePlotWithExpression(String experimentAccession, int perplexity, String geneId) {
-        Map<String, Object> namedParameters =
-                ImmutableMap.of(
-                        "experiment_accession", experimentAccession,
-                        "perplexity", perplexity,
-                        "gene_id", geneId);
-        return namedParameterJdbcTemplate.query(
-                SELECT_T_SNE_PLOT_WITH_EXPRESSION_STATEMENT,
-                namedParameters,
-                (rs, rowNum) -> TSnePoint.Dto.create(
-                        rs.getDouble("x"),
-                        rs.getDouble("y"),
-                        rs.getDouble("expression_level"),
-                        rs.getString("cell_id")));
-    }
-
-
     private static final String SELECT_T_SNE_PLOT_WITH_CLUSTERS_STATEMENT_AND_EXPRESSION =
             "SELECT tsne.cell_id, tsne.x, tsne.y, clusters.cluster_id,  analytics.expression_level  " +
                     "FROM scxa_tsne AS tsne " +
@@ -68,6 +43,30 @@ public class TSnePlotDao {
                         rs.getDouble("y"),
                         rs.getDouble("expression_level"),
                         rs.getInt("cluster_id"),
+                        rs.getString("cell_id")));
+    }
+
+    private static final String SELECT_T_SNE_PLOT_WITH_EXPRESSION_STATEMENT =
+            "SELECT tsne.cell_id, tsne.x, tsne.y, analytics.expression_level " +
+                    "FROM scxa_tsne AS tsne " +
+                    "LEFT JOIN " +
+                    "(SELECT * FROM scxa_analytics WHERE gene_id=:gene_id) AS analytics " +
+                    "ON analytics.cell_id=tsne.cell_id AND analytics.experiment_accession=tsne.experiment_accession " +
+                    "WHERE tsne.experiment_accession=:experiment_accession AND tsne.perplexity=:perplexity";
+    @Transactional(transactionManager = "txManager", readOnly = true)
+    public List<TSnePoint.Dto> fetchTSnePlotWithExpression(String experimentAccession, int perplexity, String geneId) {
+        Map<String, Object> namedParameters =
+                ImmutableMap.of(
+                        "experiment_accession", experimentAccession,
+                        "perplexity", perplexity,
+                        "gene_id", geneId);
+        return namedParameterJdbcTemplate.query(
+                SELECT_T_SNE_PLOT_WITH_EXPRESSION_STATEMENT,
+                namedParameters,
+                (rs, rowNum) -> TSnePoint.Dto.create(
+                        rs.getDouble("x"),
+                        rs.getDouble("y"),
+                        rs.getDouble("expression_level"),
                         rs.getString("cell_id")));
     }
 

--- a/sc/src/main/java/uk/ac/ebi/atlas/tsne/TSnePlotService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/tsne/TSnePlotService.java
@@ -102,4 +102,32 @@ public class TSnePlotService {
                                         StringUtils.capitalize(metadataValuesForCells.get(pointDto.name()))))
                 .collect(groupingBy(TSnePoint::metadata, mapping(Function.identity(), Collectors.toSet())));
     }
+
+    public Map<String, Set<TSnePoint>> fetchTSnePlotWithExpressionAndMetadata(String experimentAccession,
+                                                                               int perplexity,
+                                                                               String geneId,
+                                                                               String metadataCategory) {
+        List<TSnePoint.Dto> points = tSnePlotDao.fetchTSnePlotWithExpression(experimentAccession, perplexity, geneId);
+        List<String> cellIds = points
+                .stream()
+                .map(TSnePoint.Dto::name)
+                .collect(Collectors.toList());
+
+        Map<String, String> metadataValuesForCells =
+                cellMetadataDao.getMetadataValueForCellIds(
+                        experimentAccession,
+                        SingleCellAnalyticsCollectionProxy.metadataAsSchemaField(metadataCategory),
+                        cellIds);
+
+        return points.stream()
+                .map(
+                        pointDto ->
+                                TSnePoint.create(
+                                        MathUtils.round(pointDto.x(), 2),
+                                        MathUtils.round(pointDto.y(), 2),
+                                        pointDto.expressionLevel(),
+                                        pointDto.name(),
+                                        StringUtils.capitalize(metadataValuesForCells.get(pointDto.name()))))
+                .collect(groupingBy(TSnePoint::metadata, mapping(Function.identity(), Collectors.toSet())));
+    }
 }

--- a/sc/src/main/java/uk/ac/ebi/atlas/tsne/TSnePlotService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/tsne/TSnePlotService.java
@@ -40,6 +40,25 @@ public class TSnePlotService {
                 .collect(toSet());
     }
 
+    public Map<Integer, Set<TSnePoint>> fetchTSnePlotWithExpressionAndClusters(String experimentAccession, int perplexity, String geneId, int k) {
+        List<TSnePoint.Dto> points = tSnePlotDao.fetchTSnePlotWithClustersAndExpression(experimentAccession, perplexity, k, geneId);
+
+        return points.stream()
+                .collect(groupingBy(TSnePoint.Dto::clusterId))
+                .entrySet().stream()
+                .collect(toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().stream()
+                                .map(
+                                        pointDto ->
+                                                TSnePoint.create(
+                                                        MathUtils.round(pointDto.x(), 2),
+                                                        MathUtils.round(pointDto.y(), 2),
+                                                        pointDto.expressionLevel(),
+                                                        pointDto.name()))
+                                .collect(toSet())));
+    }
+
     public Map<Integer, Set<TSnePoint>> fetchTSnePlotWithClusters(String experimentAccession, int perplexity, int k) {
         List<TSnePoint.Dto> points = tSnePlotDao.fetchTSnePlotWithClusters(experimentAccession, perplexity, k);
 

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
@@ -77,17 +77,17 @@ class JsonExperimentTSnePlotControllerWIT {
     }
 
     @Test
-    void validJsonForExpressedGeneId() throws Exception {
+    void validJsonForExpressedGeneIdWithClusters() throws Exception {
         String experimentAccession = jdbcTestUtils.fetchRandomSingleCellExperimentAccession();
         String geneId = jdbcTestUtils.fetchRandomGeneFromSingleCellExperiment(experimentAccession);
         // If our fixtures contained full experiments we could use any random perplexity with
         // fetchRandomPerplexityFromExperimentTSne(experimentAccession), but since we have a subset of all the rows, we
         // need to restrict this value to the perplexities actually available for the particular gene we choose.
         int perplexity = jdbcTestUtils.fetchRandomPerplexityFromExperimentTSne(experimentAccession, geneId);
-
+        int cluster = jdbcTestUtils.fetchRandomKFromCellClusters(experimentAccession);
         this.mockMvc
                 .perform(get(
-                        "/json/experiments/" + experimentAccession + "/tsneplot/" + perplexity +
+                        "/json/experiments/" + experimentAccession + "/tsneplot/" + perplexity + "/clusters/k/" + cluster +
                         "/expression/" + geneId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
@@ -103,10 +103,11 @@ class JsonExperimentTSnePlotControllerWIT {
     void validJsonForInvalidGeneId() throws Exception {
         String experimentAccession = jdbcTestUtils.fetchRandomSingleCellExperimentAccession();
         int perplexity = jdbcTestUtils.fetchRandomPerplexityFromExperimentTSne(experimentAccession);
+        int cluster = jdbcTestUtils.fetchRandomKFromCellClusters(experimentAccession);
 
         this.mockMvc
                 .perform(get(
-                        "/json/experiments/" + experimentAccession + "/tsneplot/" + perplexity + "/expression/FOOBAR"))
+                        "/json/experiments/" + experimentAccession + "/tsneplot/" + perplexity  + "/clusters/k/" + cluster + "/expression/FOOBAR"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.min").doesNotExist())
@@ -120,9 +121,10 @@ class JsonExperimentTSnePlotControllerWIT {
     void noExpressionForEmptyGeneId() throws Exception {
         String experimentAccession = jdbcTestUtils.fetchRandomSingleCellExperimentAccession();
         int perplexity = jdbcTestUtils.fetchRandomPerplexityFromExperimentTSne(experimentAccession);
+        int cluster = jdbcTestUtils.fetchRandomKFromCellClusters(experimentAccession);
 
         this.mockMvc
-                .perform(get("/json/experiments/" + experimentAccession + "/tsneplot/" + perplexity + "/expression/"))
+                .perform(get("/json/experiments/" + experimentAccession + "/tsneplot/" + perplexity + "/clusters/k/" + cluster + "/expression/"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.min").doesNotExist())

--- a/sc/src/test/java/uk/ac/ebi/atlas/tsne/TSnePlotDaoIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/tsne/TSnePlotDaoIT.java
@@ -84,6 +84,20 @@ class TSnePlotDaoIT {
 
     @ParameterizedTest
     @MethodSource("randomExperimentAccessionKAndPerplexityProvider")
+    void testExpressionAndClusters(String experimentAccession, int k, int perplexity) {
+        String geneId = jdbcTestUtils.fetchRandomGeneFromSingleCellExperiment(experimentAccession);
+
+        assertThat(subject.fetchTSnePlotWithClustersAndExpression(experimentAccession, perplexity, k, geneId))
+                .isNotEmpty()
+                .doesNotHaveDuplicates()
+                .allMatch(tSnePointDto -> tSnePointDto.expressionLevel() >= 0.0)
+                .allMatch(tSnePointDto -> tSnePointDto.clusterId() <= k)
+                .extracting("name")
+                .isSubsetOf(fetchCellIds(experimentAccession));
+    }
+
+    @ParameterizedTest
+    @MethodSource("randomExperimentAccessionKAndPerplexityProvider")
     void testClustersForK(String experimentAccession, int k, int perplexity) {
         assertThat(subject.fetchTSnePlotWithClusters(experimentAccession, perplexity, k))
                 .isNotEmpty()


### PR DESCRIPTION
In this feature branch, I implement four new endpoints for gene expression json payload to synch tSne plots in SC experiment page. As the cluster tsne may be coloured by metadata or cluster, gene expression endpoints need to provide corresponding clustered data and also be compatible with an empty geneID query. In this case, four endpoints are introduced and the old endpoint for providing a single array is deleted. This new feature is visualized in the [scxa-experiment-page-tsne-plot-view](https://github.com/ebi-gene-expression-group/scxa-experiment-page-tsne-plot-view/tree/feature/164403270-sync-tsnes-with-legend).
