### PR TITLE
Bugfix #164689363 – Differential species in plants landing in lowercase

### DIFF
--- a/gxa/src/main/webapp/WEB-INF/jsp/tiles/views/baseline-plants-landing-page/species-icon-selector.jsp
+++ b/gxa/src/main/webapp/WEB-INF/jsp/tiles/views/baseline-plants-landing-page/species-icon-selector.jsp
@@ -1,5 +1,6 @@
 <%--@elvariable id="species" type="String"--%>
-<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page contentType="text/html;charset=UTF-8" %>
+<c:set var="species" value="${species.substring(0, 1).toUpperCase()}${species.substring(1).toLowerCase()}"/>
 <c:choose>
     <c:when test="${species == 'Anolis carolinensis'}">
         <c:set var="speciesIconCode" value="7"/>


### PR DESCRIPTION
I spotted  a bug buried in the plants landing page. To aggregate species (e.g. *Oryza sativa Indica group* and *Oryza sativa Japoniga group* under *Oryza sativa*) we use the reference name which is in lower case, and the `species-icon-selector.jsp` expects them to be capitalised.

Let’s merge this into the release branch and then onto `dev`.