### PR TITLE
Hotfix #164800575 – Fix file leak on release metadata

### DIFF
--- a/base/src/main/java/uk/ac/ebi/atlas/species/AtlasInformationDao.java
+++ b/base/src/main/java/uk/ac/ebi/atlas/species/AtlasInformationDao.java
@@ -31,7 +31,7 @@ public class AtlasInformationDao {
                         return atlasInformation;
                     } catch (IOException e) {
                         return ImmutableMap.of(
-                                "ensembl", "foo",
+                                "ensembl", "unknown",
                                 "ensembl_genomes", "unknown",
                                 "wormbase_parasite", "unknown",
                                 "efo", "unknown");

--- a/base/src/test/java/uk/ac/ebi/atlas/species/AtlasInformationDaoTest.java
+++ b/base/src/test/java/uk/ac/ebi/atlas/species/AtlasInformationDaoTest.java
@@ -1,0 +1,52 @@
+package uk.ac.ebi.atlas.species;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AtlasInformationDaoTest {
+    private AtlasInformationDao subject;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        File tmpFile = File.createTempFile("foo", ".json");
+
+        tmpFile.deleteOnExit();
+        try {
+            Files.write(
+                    tmpFile.toPath(),
+                    ImmutableList.of(
+                            "{",
+                            "  \"ensembl\": \"94\",\n",
+                            "  \"ensembl_genomes\": \"41\",\n",
+                            "  \"wormbase_parasite\": \"11\",\n",
+                            "  \"efo\": \"2.98\"\n" +
+                            "}"),
+                    Charset.forName("UTF-8"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        subject = new AtlasInformationDao(tmpFile.toPath());
+    }
+
+    @Test
+    void retrievesData() {
+        assertThat(subject.fetchAll())
+                .containsAllEntriesOf(
+                        ImmutableMap.of(
+                                "ensembl", "94",
+                                "ensembl_genomes", "41",
+                                "wormbase_parasite", "11",
+                                "efo", "2.98"));
+    }
+}

--- a/gxa/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
+++ b/gxa/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
@@ -2,7 +2,6 @@ package uk.ac.ebi.atlas.home;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -91,7 +90,7 @@ public class HomeController {
                         .sum();
         model.addAttribute("numberOfAssays", numberOfAssays);
 
-        Map<String, String> atlasInformation = atlasInformationDao.fetchAll();
+        Map<String, String> atlasInformation = atlasInformationDao.atlasInformation.get();
         model.addAttribute("info", atlasInformation);
         model.addAttribute("ensembl", ENSEMBL.getId());
         model.addAttribute("genomes", GENOMES.getId());


### PR DESCRIPTION
I replaced the logic that reads from the JSON each time the homepage is accessed by a `LazyReference` which guarantees that the file is read only once in a thread-safe way.

The test that asks for no files is not strictly true, since the file could be left open, but wrapping it in a `LazyReference` ensures that at most one file handle is used. Testing that it’s a `LazyReference` exposes implementation details that the test shouldn’t care about, but we cannot test that a file referenced by a `Path` isn’t kept open by the JRE.