### PR TITLE
Add endpoint to get metadata for tsne plot widget

### DIFF
--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
@@ -59,10 +59,7 @@ public class ExperimentPageContentService {
     }
 
     public JsonArray getTsnePlotMetaData(String experimentAccession) {
-        JsonObject result = new JsonObject();
-        result.add("metadata", getMetadata(experimentAccession));
-
-        return result.getAsJsonArray("metadata");
+        return getMetadata(experimentAccession);
     }
 
     public JsonObject getExperimentDesign(String experimentAccession,

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
@@ -46,15 +46,7 @@ public class ExperimentPageContentService {
         tsnePlotSettingsService.getAvailablePerplexities(experimentAccession).forEach(perplexityArray::add);
         result.add("perplexities", perplexityArray);
 
-        JsonArray metadataArray = new JsonArray();
-        Stream.concat(
-                cellMetadataDao.getMetadataFieldNames(experimentAccession).stream(),
-                cellMetadataDao.getAdditionalAttributesFieldNames(experimentAccession).stream())
-                .map(x -> ImmutableMap.of("value", x.name(), "label", x.displayName()))
-                .collect(Collectors.toSet())
-                .forEach(x -> metadataArray.add(GSON.toJsonTree(x)));
-
-        result.add("metadata", metadataArray);
+        result.add("metadata", getMetadata(experimentAccession));
 
         JsonArray units = new JsonArray();
         units.add("TPM");
@@ -62,6 +54,13 @@ public class ExperimentPageContentService {
         result.add("units", units);
 
         result.addProperty("suggesterEndpoint", "json/suggestions");
+
+        return result;
+    }
+
+    public JsonObject getTsnePlotMetaData(String experimentAccession) {
+        JsonObject result = new JsonObject();
+        result.add("metadata", getMetadata(experimentAccession));
 
         return result;
     }
@@ -144,5 +143,17 @@ public class ExperimentPageContentService {
         section.add("files", files);
 
         return section;
+    }
+
+    private JsonArray getMetadata(String experimentAccession) {
+        JsonArray metadataArray = new JsonArray();
+        Stream.concat(
+                cellMetadataDao.getMetadataFieldNames(experimentAccession).stream(),
+                cellMetadataDao.getAdditionalAttributesFieldNames(experimentAccession).stream())
+                .map(x -> ImmutableMap.of("value", x.name(), "label", x.displayName()))
+                .collect(Collectors.toSet())
+                .forEach(x -> metadataArray.add(GSON.toJsonTree(x)));
+
+        return metadataArray;
     }
 }

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
@@ -58,11 +58,11 @@ public class ExperimentPageContentService {
         return result;
     }
 
-    public JsonObject getTsnePlotMetaData(String experimentAccession) {
+    public JsonArray getTsnePlotMetaData(String experimentAccession) {
         JsonObject result = new JsonObject();
         result.add("metadata", getMetadata(experimentAccession));
 
-        return result;
+        return result.getAsJsonArray("metadata");
     }
 
     public JsonObject getExperimentDesign(String experimentAccession,

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -2,7 +2,7 @@ package uk.ac.ebi.atlas.experimentpage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -82,7 +82,7 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
         Experiment experiment = experimentTrader.getExperiment(experimentAccession, accessKey);
 
         // need to have this check in case there is no metadata for specified experiment
-        if(getTSnePlotMetadata(experiment.getAccession()).equalsIgnoreCase("metadata:   []")) {
+        if(getTSnePlotMetadata(experiment.getAccession()).equalsIgnoreCase("[]")) {
             return GSON.toJson(ImmutableMap.of(
                     "series",
                     new ArrayList<Map<String, Object>>()
@@ -147,7 +147,7 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
     @ResponseBody
     public String getTSnePlotMetadata(
             @PathVariable String experimentAccession) {
-        JsonObject plotData = experimentPageContentService.getTsnePlotMetaData(experimentAccession);
+        JsonArray plotData = experimentPageContentService.getTsnePlotMetaData(experimentAccession);
         return GSON.toJson(plotData);
     }
 

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
@@ -82,12 +83,11 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
         Experiment experiment = experimentTrader.getExperiment(experimentAccession, accessKey);
 
         // need to have this check in case there is no metadata for specified experiment
-        if(getTSnePlotMetadata(experiment.getAccession()).equalsIgnoreCase("[]")) {
+        if(isNullOrEmpty(getTSnePlotMetadata(experiment.getAccession()))) {
             return GSON.toJson(ImmutableMap.of(
                     "series",
                     new ArrayList<Map<String, Object>>()
             ));
-
         }
         else {
             return GSON.toJson(
@@ -148,7 +148,11 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
     public String getTSnePlotMetadata(
             @PathVariable String experimentAccession) {
         JsonArray plotData = experimentPageContentService.getTsnePlotMetaData(experimentAccession);
-        return GSON.toJson(plotData);
+        if(plotData.size() == 0) {
+            return null;
+        } else {
+            return GSON.toJson(plotData);
+        }
     }
 
     private List<Map<String, Object>> modelForHighcharts(String seriesNamePrefix, Map<?, Set<TSnePoint>> points) {

--- a/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/sc/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -2,7 +2,6 @@ package uk.ac.ebi.atlas.experimentpage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -83,7 +82,7 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
         Experiment experiment = experimentTrader.getExperiment(experimentAccession, accessKey);
 
         // need to have this check in case there is no metadata for specified experiment
-        if(getTSnePlotMetadata(experiment.getAccession()).equalsIgnoreCase("[]")) {
+        if(getTSnePlotMetadata(experiment.getAccession()).equalsIgnoreCase("metadata:   []")) {
             return GSON.toJson(ImmutableMap.of(
                     "series",
                     new ArrayList<Map<String, Object>>()
@@ -148,10 +147,8 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
     @ResponseBody
     public String getTSnePlotMetadata(
             @PathVariable String experimentAccession) {
-        JsonObject plotData = experimentPageContentService.getTsnePlotData(experimentAccession);
-        return plotData.getAsJsonArray("metadata").size() == 0 ?
-                GSON.toJson(new JsonArray()) :
-                    GSON.toJson(plotData.getAsJsonArray("metadata"));
+        JsonObject plotData = experimentPageContentService.getTsnePlotMetaData(experimentAccession);
+        return GSON.toJson(plotData);
     }
 
     private List<Map<String, Object>> modelForHighcharts(String seriesNamePrefix, Map<?, Set<TSnePoint>> points) {

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
@@ -183,7 +183,7 @@ class JsonExperimentTSnePlotControllerWIT {
         mockMvc.perform(get(URL, "E-GEOD-99058"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(jsonPath("$.metadata", hasSize(equalTo(0))));
+                .andExpect(jsonPath("$", hasSize(equalTo(0))));
     }
 
     @Test

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
@@ -175,7 +175,7 @@ class JsonExperimentTSnePlotControllerWIT {
     }
 
     @Test
-    void validJsonWithValidExperimentAccessionButNoMetadata(String experimentAccession) throws Exception {
+    void validJsonWithValidExperimentAccessionButNoMetadata() throws Exception {
         mockMvc.perform(get(URL, "E-GEOD-99058"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))

--- a/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
+++ b/sc/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
@@ -26,7 +24,13 @@ import javax.sql.DataSource;
 
 import java.util.Random;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -179,7 +183,7 @@ class JsonExperimentTSnePlotControllerWIT {
         mockMvc.perform(get(URL, "E-GEOD-99058"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(jsonPath("$.[*]", hasSize(equalTo(0))));
+                .andExpect(jsonPath("$.metadata", hasSize(equalTo(0))));
     }
 
     @Test


### PR DESCRIPTION
For TSne plot widget there was a need to create an endpoint which will fetch metadata. Created a new endpoint in JsonExperimentTSnePlotController.java. 
There was a case when the experiment doesn't have metadata so to handle that implemented a check which returns an empty array if there is no metadata.

Link to green builds:
http://bar:8085/browse/ATLAS-GXACI21-2
http://bar:8085/browse/ATLAS-SCXACI20-GITCO-3